### PR TITLE
Support saving of documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-junit-reporter": "^1.2.0",
     "protractor": "~5.1.2",
+    "ts-mockito": "^2.0.2",
     "ts-node": "~3.3.0",
     "tslint": "~5.5.0",
     "typescript": "~2.4.2"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,7 +20,10 @@ import * as constants from './config/app-config';
       serviceUrl: constants.appConfig.serviceUrls.persistenceService,
       authorizationHeader: "admin:admin@example.com"
     }),
-    EditorTabsModule
+    EditorTabsModule.forRoot({
+      serviceUrl: constants.appConfig.serviceUrls.persistenceService,
+      authorizationHeader: "admin:admin@example.com"
+    })
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/editor-tabs/ace.component.html
+++ b/src/app/editor-tabs/ace.component.html
@@ -1,1 +1,1 @@
-<div [id]="myId" class="xtext-editor"><ng-content></ng-content></div>
+<div [id]="tabId + '-editor'" class="xtext-editor"><ng-content></ng-content></div>

--- a/src/app/editor-tabs/ace.component.ts
+++ b/src/app/editor-tabs/ace.component.ts
@@ -12,22 +12,18 @@ declare var createXtextEditor: any;
 })
 export class AceComponent {
 
-  static count: number = 0;
-
   @Input() initialContent: Promise<string>;
+  @Input() tabId: string;
   editor: Promise<any>;
-  myId: string;
-
-  constructor() {
-    let number = AceComponent.count++;
-    this.myId = `xtext-editor-${number}`;
-  }
+  id: string;
 
   ngAfterViewInit() {
-    let deferred: Deferred = createXtextEditor(this.myId, constants.appConfig.serviceUrls.xtextService);
+    let editorId = `${this.tabId}-editor`;
+    let deferred: Deferred = createXtextEditor(this.tabId, editorId, constants.appConfig.serviceUrls.xtextService);
     this.editor = deferred.promise;
     Promise.all([this.editor, this.initialContent]).then(([editor, content]) => {
       editor.setValue(content);
+      editor.xtextServices.editorContext.setDirty(false);
     });
   }
 

--- a/src/app/editor-tabs/ace.component.ts
+++ b/src/app/editor-tabs/ace.component.ts
@@ -1,30 +1,94 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, AfterViewInit } from '@angular/core';
 import { Deferred } from 'prophecy/src/Deferred';
+
+import { DocumentService } from './document.service';
 
 import * as constants from '../config/app-config'
 
-declare var createXtextEditor: any;
+declare var createXtextEditor: (config: any) => Deferred;
 
 @Component({
   selector: 'xtext-editor',
   templateUrl: './ace.component.html',
   styleUrls: ['./ace.component.css']
 })
-export class AceComponent {
+export class AceComponent implements AfterViewInit {
 
-  @Input() initialContent: Promise<string>;
+  @Input() path: string;
   @Input() tabId: string;
   editor: Promise<any>;
-  id: string;
 
-  ngAfterViewInit() {
+  constructor(private documentService: DocumentService) {
+  }
+
+  ngAfterViewInit(): void {
+    this.editor = this.createEditor();
+    this.editor.then(editor => this.initializeEditor(editor));
+  }
+
+  private createEditor(): Promise<any> {
     let editorId = `${this.tabId}-editor`;
-    let deferred: Deferred = createXtextEditor(this.tabId, editorId, constants.appConfig.serviceUrls.xtextService);
-    this.editor = deferred.promise;
-    Promise.all([this.editor, this.initialContent]).then(([editor, content]) => {
-      editor.setValue(content);
-      editor.xtextServices.editorContext.setDirty(false);
+    let config = {
+      baseUrl: window.location.origin,
+      serviceUrl: constants.appConfig.serviceUrls.xtextService,
+      parent: editorId,
+      dirtyElement: document.getElementsByClassName(this.tabId),
+      loadFromServer: false,
+      sendFullText: true,
+      syntaxDefinition: "xtext-resources/generated/mode-mydsl",
+      enableSaveAction: false // don't want the default xtext-save action
+    }
+    let deferred = createXtextEditor(config);
+    return deferred.promise;
+  }
+
+  private initializeEditor(editor: any): void {
+    // Set initial content
+    this.documentService.loadDocument(this.path).then(response => {
+      this.setContent(response.text());
+    }).catch(reason => {
+      this.setContent(`Could not load resource: ${this.path}\n\nReason:\n${reason}`);
+      this.setReadOnly(true);
     });
+
+    // Configure save action
+    editor.commands.addCommand({
+      name: 'angular-xtext-save',
+      bindKey: { win: 'Ctrl-S', mac: 'Command-S' },
+      exec: this.save.bind(this)
+    });
+
+    // TODO for debugging only
+    window["editor"] = editor;
+  }
+
+  private setContent(content: string): void {
+    this.editor.then(editor => {
+      editor.setValue(content);
+      this.setDirty(false);
+      editor.session.selection.clearSelection();
+    });
+  }
+
+  public save(): void {
+    this.editor.then(editor => {
+      editor.setReadOnly(true);
+      this.documentService.saveDocument(this.path, editor.getValue()).then(res => {
+        this.setDirty(false);
+        editor.setReadOnly(false);
+      }).catch(reason => {
+        console.log(reason);
+        editor.setReadOnly(false);
+      });
+    });
+  }
+
+  public setDirty(dirty: boolean): void {
+    this.editor.then(editor => editor.xtextServices.editorContext.setDirty(dirty));
+  }
+
+  public setReadOnly(readOnly: boolean): void {
+    this.editor.then(editor => editor.setReadOnly(readOnly));
   }
 
 }

--- a/src/app/editor-tabs/document.service.config.ts
+++ b/src/app/editor-tabs/document.service.config.ts
@@ -1,0 +1,4 @@
+export class DocumentServiceConfig {
+  serviceUrl: string;
+  authorizationHeader: string;
+}

--- a/src/app/editor-tabs/document.service.ts
+++ b/src/app/editor-tabs/document.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { Http, Headers, Response, RequestOptionsArgs } from '@angular/http';
+
+import 'rxjs/add/operator/toPromise';
+
+import { DocumentServiceConfig } from './document.service.config';
+
+@Injectable()
+export class DocumentService {
+
+  private serviceUrl: string;
+  private requestOptions: RequestOptionsArgs;
+
+  constructor(private http: Http, config: DocumentServiceConfig) {
+    this.serviceUrl = config.serviceUrl;
+    this.requestOptions = {
+      headers: new Headers({
+        'Authorization': config.authorizationHeader
+      })
+    };
+  }
+
+  loadDocument(path: string): Promise<Response> {
+    let url = `${this.serviceUrl}/documents/${path}`;
+    return this.http.get(url, this.requestOptions).toPromise();
+  }
+
+  saveDocument(path: string, content: string): Promise<Response> {
+    let url = `${this.serviceUrl}/documents/${path}`;
+    return this.http.put(url, content, this.requestOptions).toPromise();
+  }
+
+}

--- a/src/app/editor-tabs/editor-tabs.component.css
+++ b/src/app/editor-tabs/editor-tabs.component.css
@@ -1,3 +1,8 @@
 div {
-    height: 100%;
+  height: 100%;
+}
+
+::ng-deep .nav-item.dirty > a > span:first-of-type:after {
+  margin-left: 3px;
+  content: '*'
 }

--- a/src/app/editor-tabs/editor-tabs.component.html
+++ b/src/app/editor-tabs/editor-tabs.component.html
@@ -9,7 +9,7 @@
       [removable]="true"
       (removed)="removeTab(tab)"
       [customClass]="tab.id">
-      <xtext-editor [tabId]="tab.id" [initialContent]="tab.initialContent"></xtext-editor>
+      <xtext-editor [tabId]="tab.id" [path]="tab.path"></xtext-editor>
     </tab>
   </tabset>
 </div>

--- a/src/app/editor-tabs/editor-tabs.component.html
+++ b/src/app/editor-tabs/editor-tabs.component.html
@@ -2,14 +2,14 @@
   <tabset>
     <tab *ngFor="let tab of tabs" 
       [heading]="tab.title"
-      [id]="tab.path"
+      [id]="tab.id"
       [active]="tab.active"
       (select)="tab.active = true"
       (deselect)="tab.active = false"
       [removable]="true"
       (removed)="removeTab(tab)"
-      [customClass]="myCustomClass">
-      <xtext-editor [initialContent]="tab.initialContent"></xtext-editor>
+      [customClass]="tab.id">
+      <xtext-editor [tabId]="tab.id" [initialContent]="tab.initialContent"></xtext-editor>
     </tab>
   </tabset>
 </div>

--- a/src/app/editor-tabs/editor-tabs.component.spec.ts
+++ b/src/app/editor-tabs/editor-tabs.component.spec.ts
@@ -1,6 +1,7 @@
 import { DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { mock, when, anything, instance } from 'ts-mockito';
 
 import { TabsModule, TooltipModule } from 'ngx-bootstrap';
 import { MessagingModule, MessagingService } from '@testeditor/messaging-service';
@@ -8,6 +9,8 @@ import { WorkspaceDocument } from '@testeditor/workspace-navigator';
 
 import { AceComponent } from './ace.component';
 import { EditorTabsComponent } from './editor-tabs.component';
+import { DocumentService } from './document.service';
+import { DocumentServiceConfig } from './document.service.config';
 
 describe('EditorTabsComponent', () => {
 
@@ -29,6 +32,10 @@ describe('EditorTabsComponent', () => {
   };
 
   beforeEach(async(() => {
+    // Mock DocumentService
+    let documentServiceMock = mock(DocumentService)
+
+    // Initialize TestBed
     TestBed.configureTestingModule({
       imports: [
         TabsModule.forRoot(),
@@ -38,6 +45,9 @@ describe('EditorTabsComponent', () => {
       declarations: [
         AceComponent,
         EditorTabsComponent
+      ],
+      providers: [
+       { provide: DocumentService, useValue: instance(documentServiceMock) }
       ]
     })
     .compileComponents();
@@ -72,7 +82,7 @@ describe('EditorTabsComponent', () => {
     // given
     messagingService.publish('navigation.open', fooDocument);
     fixture.detectChanges();
-    
+
     // when
     messagingService.publish('navigation.open', barDocument);
     fixture.detectChanges();

--- a/src/app/editor-tabs/editor-tabs.component.ts
+++ b/src/app/editor-tabs/editor-tabs.component.ts
@@ -47,8 +47,7 @@ export class EditorTabsComponent implements OnInit, OnDestroy {
         id: `editor-tab-${EditorTabsComponent.uniqueTabId++}`,
         title: document.name,
         path: document.path,
-        active: true,
-        initialContent: document.content
+        active: true
       };
       this.tabs.push(newElement);
     }
@@ -56,6 +55,8 @@ export class EditorTabsComponent implements OnInit, OnDestroy {
   }
 
   public removeTab(tab: TabElement): void {
+    // TODO first we should check the dirty state of the editor?!
+    // see http://valor-software.com/ngx-bootstrap/#/modals - Static modal
     this.tabs.splice(this.tabs.indexOf(tab), 1);
   }
 

--- a/src/app/editor-tabs/editor-tabs.component.ts
+++ b/src/app/editor-tabs/editor-tabs.component.ts
@@ -14,6 +14,12 @@ import { TabElement } from './tab-element';
 })
 export class EditorTabsComponent implements OnInit, OnDestroy {
 
+  /** 
+   * Provide unique id's for tabs to assign them a unique css class.
+   * This is used for the dirty flag.
+   */
+  static uniqueTabId: number = 0;
+
   public tabs: TabElement[] = [];
   private subscription: Subscription;
 
@@ -38,6 +44,7 @@ export class EditorTabsComponent implements OnInit, OnDestroy {
       existingTab.active = true;
     } else {
       let newElement = {
+        id: `editor-tab-${EditorTabsComponent.uniqueTabId++}`,
         title: document.name,
         path: document.path,
         active: true,

--- a/src/app/editor-tabs/editor-tabs.module.ts
+++ b/src/app/editor-tabs/editor-tabs.module.ts
@@ -5,6 +5,8 @@ import { TabsModule, TooltipModule } from 'ngx-bootstrap';
 
 import { AceComponent } from './ace.component';
 import { EditorTabsComponent } from './editor-tabs.component';
+import { DocumentService } from './document.service';
+import { DocumentServiceConfig } from './document.service.config';
 
 @NgModule({
   imports: [
@@ -22,4 +24,15 @@ import { EditorTabsComponent } from './editor-tabs.component';
   ]
 })
 export class EditorTabsModule {
+
+  static forRoot(config: DocumentServiceConfig): ModuleWithProviders {
+    return {
+      ngModule: EditorTabsModule,
+      providers: [
+        { provide: DocumentServiceConfig, useValue: config },
+        DocumentService
+      ]
+    }
+  }
+
 }

--- a/src/app/editor-tabs/tab-element.ts
+++ b/src/app/editor-tabs/tab-element.ts
@@ -3,5 +3,4 @@ export class TabElement {
   title: string;
   path: string;
   active: boolean;
-  initialContent: Promise<string>;
 }

--- a/src/app/editor-tabs/tab-element.ts
+++ b/src/app/editor-tabs/tab-element.ts
@@ -1,4 +1,5 @@
 export class TabElement {
+  id: string;
   title: string;
   path: string;
   active: boolean;

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -43,13 +43,14 @@ require(["xtext/services/XtextService"], xtextService => {
     };
 });
 
-function createXtextEditor(parent, serviceUrl) {
+function createXtextEditor(tabClass, parent, serviceUrl) {
     let deferred = new Deferred();
     require(["xtext/xtext-ace"], xtext => {
         let editor = xtext.createEditor({
             baseUrl: baseUrl,
             serviceUrl: serviceUrl,
             parent: parent,
+            dirtyElement: document.getElementsByClassName(tabClass),
             loadFromServer: false,
             sendFullText: true,
             syntaxDefinition: "xtext-resources/generated/mode-mydsl",

--- a/src/assets/main.js
+++ b/src/assets/main.js
@@ -43,19 +43,10 @@ require(["xtext/services/XtextService"], xtextService => {
     };
 });
 
-function createXtextEditor(tabClass, parent, serviceUrl) {
+function createXtextEditor(config) {
     let deferred = new Deferred();
     require(["xtext/xtext-ace"], xtext => {
-        let editor = xtext.createEditor({
-            baseUrl: baseUrl,
-            serviceUrl: serviceUrl,
-            parent: parent,
-            dirtyElement: document.getElementsByClassName(tabClass),
-            loadFromServer: false,
-            sendFullText: true,
-            syntaxDefinition: "xtext-resources/generated/mode-mydsl",
-            enableSaveAction: true
-        });
+        let editor = xtext.createEditor(config);
         deferred.resolve(editor);
     });
     return deferred;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2866,7 +2866,7 @@ lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4802,6 +4802,12 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+ts-mockito@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ts-mockito/-/ts-mockito-2.0.2.tgz#82010ca3890107f891f7becb6d2fa29d52c88d42"
+  dependencies:
+    lodash "^4.15.0"
 
 ts-node@~3.3.0:
   version "3.3.0"


### PR DESCRIPTION
Please review #13 first and then change the base of this PR to develop.

:warning:
In contrast to what we discussed, the editor component now directly talks to the persistence service for loading and saving elements. This feels more lightweight than defining events... especially for saving we would need to define an event "I want to save" which would need to be confirmed by an "Ok, I saved your content" so that the dirty flag can be reset. 