### PR TITLE
Feature/syntax highlighting

### DIFF
--- a/src/app/editor-tabs/ace.component.spec.ts
+++ b/src/app/editor-tabs/ace.component.spec.ts
@@ -1,19 +1,24 @@
 import { AceComponent } from './ace.component';
 import { async, ComponentFixture, TestBed, inject } from '@angular/core/testing';
-import { mock, when, anything, instance } from 'ts-mockito';
+import { mock, when, anything, instance, anyString } from 'ts-mockito';
 import { MessagingModule } from '@testeditor/messaging-service';
 
 import { DocumentService } from '../../service/document/document.service';
 import { Deferred } from 'prophecy/src/Deferred';
+import { SyntaxHighlightingService } from 'service/syntaxHighlighting/syntax.highlighting.service';
+import { ViewChild, Component } from '@angular/core';
+import { AceClientsideSyntaxHighlightingService } from 'service/syntaxHighlighting/ace.clientside.syntax.highlighting.service';
 
 describe('AceComponent', () => {
-
-  let fixture: ComponentFixture<AceComponent>;
-  let component: AceComponent;
+  let hostComponent: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
 
   beforeEach(async(() => {
     // Mock DocumentService
-    let documentServiceMock = mock(DocumentService)
+    const documentServiceMock = mock(DocumentService);
+    const syntaxHighlightingServiceMock = mock(AceClientsideSyntaxHighlightingService);
+    when(syntaxHighlightingServiceMock.getSyntaxHighlighting(anyString()))
+      .thenReturn(Promise.resolve('path/to/syntax-highlighting-file.js'));
 
     // Initialize TestBed
     TestBed.configureTestingModule({
@@ -21,22 +26,37 @@ describe('AceComponent', () => {
         MessagingModule.forRoot()
       ],
       declarations: [
-        AceComponent
+        TestHostComponent, AceComponent
       ],
       providers: [
-        { provide: DocumentService, useValue: instance(documentServiceMock) }
+        { provide: DocumentService, useValue: instance(documentServiceMock) },
+        { provide: SyntaxHighlightingService, useValue: instance(syntaxHighlightingServiceMock) }
       ]
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(AceComponent);
-    component = fixture.componentInstance;
+    fixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = fixture.componentInstance;
+    hostComponent.path = 'path/to/file';
+    hostComponent.tabId = 'theTabID';
     fixture.detectChanges();
   });
 
   it('should be created', () => {
-    expect(component).toBeTruthy();
+    expect(hostComponent.aceComponentUnderTest).toBeTruthy();
   });
+
+  @Component({
+    selector: `app-host-component`,
+    template: `<xtext-editor [path]="path" [tabId]="tabId"></xtext-editor>`
+  })
+  class TestHostComponent {
+    public path: string;
+    public tabId: string;
+
+    @ViewChild(AceComponent)
+    public aceComponentUnderTest: AceComponent;
+  }
 
 });

--- a/src/app/editor-tabs/ace.component.ts
+++ b/src/app/editor-tabs/ace.component.ts
@@ -8,6 +8,8 @@ import { DirtyState } from './dirty-state';
 import * as constants from '../config/app-config'
 import * as events from './event-types';
 
+import { SyntaxHighlightingService } from 'service/syntaxHighlighting/syntax.highlighting.service';
+
 declare var createXtextEditor: (config: any) => Deferred;
 
 @Component({
@@ -21,7 +23,8 @@ export class AceComponent implements AfterViewInit {
   @Input() tabId: string;
   editor: Promise<any>;
 
-  constructor(private documentService: DocumentService, private messagingService: MessagingService) {
+  constructor(private documentService: DocumentService, private messagingService: MessagingService,
+    private syntaxHighlightingService: SyntaxHighlightingService) {
   }
 
   ngAfterViewInit(): void {
@@ -30,20 +33,22 @@ export class AceComponent implements AfterViewInit {
   }
 
   private createEditor(): Promise<any> {
-    let editorId = `${this.tabId}-editor`;
-    let config = {
-      baseUrl: window.location.origin,
-      serviceUrl: constants.appConfig.serviceUrls.xtextService,
-      parent: editorId,
-      dirtyElement: document.getElementsByClassName(this.tabId),
-      loadFromServer: false,
-      sendFullText: true,
-      resourceId: this.path,
-      syntaxDefinition: "xtext-resources/generated/mode-tsl",
-      enableSaveAction: false // don't want the default xtext-save action
-    }
-    let deferred = createXtextEditor(config);
-    return deferred.promise;
+    const editorId = `${this.tabId}-editor`;
+    return this.findSyntaxDefinitionFile().then(syntaxDefinitionFilePath => {
+      const config = {
+        baseUrl: window.location.origin,
+        serviceUrl: constants.appConfig.serviceUrls.xtextService,
+        parent: editorId,
+        dirtyElement: document.getElementsByClassName(this.tabId),
+        loadFromServer: false,
+        sendFullText: true,
+        resourceId: this.path,
+        syntaxDefinition: syntaxDefinitionFilePath,
+        enableSaveAction: false // don't want the default xtext-save action
+      }
+      const deferred = createXtextEditor(config);
+      return deferred.promise;
+    });
   }
 
   private initializeEditor(editor: any): void {
@@ -81,6 +86,26 @@ export class AceComponent implements AfterViewInit {
       dirty: dirty
     }
     this.messagingService.publish(events.EDITOR_DIRTY_CHANGED, dirtyState);
+  }
+
+  private findSyntaxDefinitionFile(): Promise<string> {
+    return this.syntaxHighlightingService.getSyntaxHighlighting(this.getFileExtension())
+      .then(path => {
+        console.log(`using syntax highlighting rules from "${path}"`);
+        return path;
+      })
+      .catch(() => {
+        console.log(`no syntax highlighting rules available for this file type ("${this.path}")`);
+        return 'none';
+      });
+  }
+
+  private getFileExtension(): string {
+    const extensionBeginsAt = this.path.lastIndexOf('.') + 1;
+    if (extensionBeginsAt !== -1 && this.path.length > extensionBeginsAt) {
+      return this.path.substring(extensionBeginsAt);
+    }
+    return '';
   }
 
   public focus(): void {

--- a/src/app/editor-tabs/ace.component.ts
+++ b/src/app/editor-tabs/ace.component.ts
@@ -101,9 +101,9 @@ export class AceComponent implements AfterViewInit {
   }
 
   private getFileExtension(): string {
-    const extensionBeginsAt = this.path.lastIndexOf('.') + 1;
-    if (extensionBeginsAt !== -1 && this.path.length > extensionBeginsAt) {
-      return this.path.substring(extensionBeginsAt);
+    const extensionBeginsAfter = this.path.lastIndexOf('.');
+    if (extensionBeginsAfter !== -1 && this.path.length > extensionBeginsAfter + 1) {
+      return this.path.substring(extensionBeginsAfter + 1);
     }
     return '';
   }

--- a/src/app/editor-tabs/editor-tabs.component.spec.ts
+++ b/src/app/editor-tabs/editor-tabs.component.spec.ts
@@ -1,7 +1,7 @@
 import { DebugElement, Component } from '@angular/core';
 import { async, ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { mock, when, anything, instance } from 'ts-mockito';
+import { mock, when, anything, instance, anyString } from 'ts-mockito';
 
 import { TabsModule, TooltipModule } from 'ngx-bootstrap';
 import { MessagingModule, MessagingService } from '@testeditor/messaging-service';
@@ -12,6 +12,8 @@ import { DocumentService } from '../../service/document/document.service';
 import { DocumentServiceConfig } from '../../service/document/document.service.config';
 
 import { NAVIGATION_DELETED, NavigationDeletedPayload, NAVIGATION_OPEN, NavigationOpenPayload, EDITOR_ACTIVE, EDITOR_CLOSE } from './event-types';
+import { AceClientsideSyntaxHighlightingService } from 'service/syntaxHighlighting/ace.clientside.syntax.highlighting.service';
+import { SyntaxHighlightingService } from 'service/syntaxHighlighting/syntax.highlighting.service';
 
 describe('EditorTabsComponent', () => {
 
@@ -52,7 +54,10 @@ describe('EditorTabsComponent', () => {
 
   beforeEach(async(() => {
     // Mock DocumentService
-    let documentServiceMock = mock(DocumentService)
+    const documentServiceMock = mock(DocumentService);
+    const syntaxHighlightingServiceMock = mock(AceClientsideSyntaxHighlightingService);
+    when(syntaxHighlightingServiceMock.getSyntaxHighlighting(anyString()))
+      .thenReturn(Promise.resolve('path/to/syntax-highlighting-file.js'));
 
     // Initialize TestBed
     TestBed.configureTestingModule({
@@ -66,7 +71,8 @@ describe('EditorTabsComponent', () => {
         EditorTabsComponent
       ],
       providers: [
-        { provide: DocumentService, useValue: instance(documentServiceMock) }
+        { provide: DocumentService, useValue: instance(documentServiceMock) },
+        { provide: SyntaxHighlightingService, useValue: instance(syntaxHighlightingServiceMock) }
       ]
     })
       .compileComponents();

--- a/src/app/editor-tabs/editor-tabs.module.ts
+++ b/src/app/editor-tabs/editor-tabs.module.ts
@@ -7,6 +7,8 @@ import { AceComponent } from './ace.component';
 import { EditorTabsComponent } from './editor-tabs.component';
 import { DocumentService } from '../../service/document/document.service';
 import { DocumentServiceConfig } from '../../service/document/document.service.config';
+import { SyntaxHighlightingService } from '../../service/syntaxHighlighting/syntax.highlighting.service';
+import { AceClientsideSyntaxHighlightingService } from '../../service/syntaxHighlighting/ace.clientside.syntax.highlighting.service';
 
 @NgModule({
   imports: [
@@ -30,6 +32,7 @@ export class EditorTabsModule {
       ngModule: EditorTabsModule,
       providers: [
         { provide: DocumentServiceConfig, useValue: config },
+        { provide: SyntaxHighlightingService, useClass: AceClientsideSyntaxHighlightingService },
         DocumentService
       ]
     }

--- a/src/assets/xtext-resources/generated/mode-aml.js
+++ b/src/assets/xtext-resources/generated/mode-aml.js
@@ -1,0 +1,36 @@
+define(["ace/lib/oop", "ace/mode/text", "ace/mode/text_highlight_rules"], function(oop, mText, mTextHighlightRules) {
+	var HighlightRules = function() {
+		var keywords = "abstract|allActionGroups|as|by|case|catch|component|default|do|element|else|extends|extension|false|finally|for|generate|if|import|includes|instanceof|interaction|interactions|is|label|locate|locator|locatorStrategy|method|new|null|package|restrict|return|static|super|switch|synchronized|technicalBindings|template|throw|to|true|try|type|typeof|using|val|var|while";
+		this.$rules = {
+			"start": [
+				{token: "comment", regex: "\\/\\/.*$"},
+				{token: "comment", regex: "\\/\\*", next : "comment"},
+				{token: "string", regex: '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'},
+				{token: "string", regex: "['](?:(?:\\\\.)|(?:[^'\\\\]))*?[']"},
+				{token: "constant.numeric", regex: "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b"},
+				{token: "constant.numeric", regex: "0[xX][0-9a-fA-F]+\\b"},
+				{token: "lparen", regex: "[\\[({]"},
+				{token: "rparen", regex: "[\\])}]"},
+				{token: "keyword", regex: "\\b(?:" + keywords + ")\\b"}
+			],
+			"comment": [
+				{token: "comment", regex: ".*?\\*\\/", next : "start"},
+				{token: "comment", regex: ".+"}
+			]
+		};
+	};
+	oop.inherits(HighlightRules, mTextHighlightRules.TextHighlightRules);
+	
+	var Mode = function() {
+		this.HighlightRules = HighlightRules;
+	};
+	oop.inherits(Mode, mText.Mode);
+	Mode.prototype.$id = "xtext/aml";
+	Mode.prototype.getCompletions = function(state, session, pos, prefix) {
+		return [];
+	}
+	
+	return {
+		Mode: Mode
+	};
+});

--- a/src/assets/xtext-resources/generated/mode-tcl.js
+++ b/src/assets/xtext-resources/generated/mode-tcl.js
@@ -1,0 +1,36 @@
+define(["ace/lib/oop", "ace/mode/text", "ace/mode/text_highlight_rules"], function(oop, mText, mTextHighlightRules) {
+	var HighlightRules = function() {
+		var keywords = "Cleanup|Component|Macro|Mask|Setup|as|assert|case|catch|config|default|do|does|else|extends|extension|false|finally|for|if|implements|import|instanceof|is|match|matches|new|not|null|package|public|require|return|static|super|switch|synchronized|template|throw|true|try|typeof|val|var|while";
+		this.$rules = {
+			"start": [
+				{token: "comment", regex: "\\/\\/.*$"},
+				{token: "comment", regex: "\\/\\*", next : "comment"},
+				{token: "string", regex: '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'},
+				{token: "string", regex: "['](?:(?:\\\\.)|(?:[^'\\\\]))*?[']"},
+				{token: "constant.numeric", regex: "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b"},
+				{token: "constant.numeric", regex: "0[xX][0-9a-fA-F]+\\b"},
+				{token: "lparen", regex: "[\\[({]"},
+				{token: "rparen", regex: "[\\])}]"},
+				{token: "keyword", regex: "\\b(?:" + keywords + ")\\b"}
+			],
+			"comment": [
+				{token: "comment", regex: ".*?\\*\\/", next : "start"},
+				{token: "comment", regex: ".+"}
+			]
+		};
+	};
+	oop.inherits(HighlightRules, mTextHighlightRules.TextHighlightRules);
+
+	var Mode = function() {
+		this.HighlightRules = HighlightRules;
+	};
+	oop.inherits(Mode, mText.Mode);
+	Mode.prototype.$id = "xtext/tcl";
+	Mode.prototype.getCompletions = function(state, session, pos, prefix) {
+		return [];
+	}
+
+	return {
+		Mode: Mode
+	};
+});

--- a/src/service/syntaxHighlighting/ace.clientside.syntax.highlighting.service.ts
+++ b/src/service/syntaxHighlighting/ace.clientside.syntax.highlighting.service.ts
@@ -9,7 +9,7 @@ export class AceClientsideSyntaxHighlightingService implements SyntaxHighlightin
     ['config', 'xtext-resources/generated/mode-tcl'],
     ['aml', 'xtext-resources/generated/mode-aml']]);
 
-  getSyntaxHighlighting(extension: string): Promise<any> {
+  getSyntaxHighlighting(extension: string): Promise<string> {
     const map = AceClientsideSyntaxHighlightingService.syntaxHighlightings;
     if (map.has(extension)) {
       return Promise.resolve(map.get(extension));

--- a/src/service/syntaxHighlighting/ace.clientside.syntax.highlighting.service.ts
+++ b/src/service/syntaxHighlighting/ace.clientside.syntax.highlighting.service.ts
@@ -1,0 +1,20 @@
+import { SyntaxHighlightingService } from 'service/syntaxHighlighting/syntax.highlighting.service';
+
+
+export class AceClientsideSyntaxHighlightingService implements SyntaxHighlightingService {
+  private static readonly syntaxHighlightings = new Map([
+    ['tsl', 'xtext-resources/generated/mode-tsl'],
+    ['tcl', 'xtext-resources/generated/mode-tcl'],
+    ['tml', 'xtext-resources/generated/mode-tcl'],
+    ['config', 'xtext-resources/generated/mode-tcl']/*,
+    ['aml', 'assets/xtext-resources/generated/mode-aml']*/]);
+
+  getSyntaxHighlighting(extension: string): Promise<any> {
+    const map = AceClientsideSyntaxHighlightingService.syntaxHighlightings;
+    if (map.has(extension)) {
+      return Promise.resolve(map.get(extension));
+    }
+    return Promise.reject(`No syntax highlighting available for language extension "${extension}"`);
+  }
+
+}

--- a/src/service/syntaxHighlighting/ace.clientside.syntax.highlighting.service.ts
+++ b/src/service/syntaxHighlighting/ace.clientside.syntax.highlighting.service.ts
@@ -6,8 +6,8 @@ export class AceClientsideSyntaxHighlightingService implements SyntaxHighlightin
     ['tsl', 'xtext-resources/generated/mode-tsl'],
     ['tcl', 'xtext-resources/generated/mode-tcl'],
     ['tml', 'xtext-resources/generated/mode-tcl'],
-    ['config', 'xtext-resources/generated/mode-tcl']/*,
-    ['aml', 'assets/xtext-resources/generated/mode-aml']*/]);
+    ['config', 'xtext-resources/generated/mode-tcl'],
+    ['aml', 'xtext-resources/generated/mode-aml']]);
 
   getSyntaxHighlighting(extension: string): Promise<any> {
     const map = AceClientsideSyntaxHighlightingService.syntaxHighlightings;

--- a/src/service/syntaxHighlighting/syntax.highlighting.service.spec.ts
+++ b/src/service/syntaxHighlighting/syntax.highlighting.service.spec.ts
@@ -17,21 +17,30 @@ describe('AceClientsideSyntaxHighlightingService', () => {
 
     // then
     actualExceptionReason.then(response => fail(`expected exception, but got response: ${response}`))
-    .catch(actualReason => {
-      expect(actualReason).toEqual(`No syntax highlighting available for language extension "${unknownLanguageExtension}"`);
-    });
+      .catch(actualReason => {
+        expect(actualReason).toEqual(`No syntax highlighting available for language extension "${unknownLanguageExtension}"`);
+      });
   });
 
-  it('provides Ace syntax highlighting for known language', () => {
-    // given
-    const knownLanguageExtension = 'tcl';
 
-    // when
-    const actualExceptionReason = serviceUnderTest.getSyntaxHighlighting(knownLanguageExtension)
+  // given
+  [
+    ['tcl', 'xtext-resources/generated/mode-tcl'],
+    ['tml', 'xtext-resources/generated/mode-tcl'],
+    ['config', 'xtext-resources/generated/mode-tcl'],
+    ['tsl', 'xtext-resources/generated/mode-tsl'],
+    ['aml', 'xtext-resources/generated/mode-aml']
+  ].forEach(([knownLanguageExtension, expectedSyntaxHighlightingFile]) => {
 
-    // then
-    actualExceptionReason.then(actualHighlighting => {
-      expect(actualHighlighting).toEqual('assets/xtext-resources/generated/mode-tcl');
-    }).catch(exceptionReason => fail(`unexpected exception: ${exceptionReason}`));
+    it(`provides Ace syntax highlighting file "${expectedSyntaxHighlightingFile}" for language "${knownLanguageExtension}"`, () => {
+      // when
+      const actualExceptionReason = serviceUnderTest.getSyntaxHighlighting(knownLanguageExtension)
+
+      // then
+      actualExceptionReason.then(actualHighlighting => {
+        expect(actualHighlighting).toEqual(expectedSyntaxHighlightingFile);
+      }).catch(exceptionReason => fail(`unexpected exception: ${exceptionReason}`));
+    });
+
   });
 });

--- a/src/service/syntaxHighlighting/syntax.highlighting.service.spec.ts
+++ b/src/service/syntaxHighlighting/syntax.highlighting.service.spec.ts
@@ -1,0 +1,37 @@
+import { AceClientsideSyntaxHighlightingService } from 'service/syntaxHighlighting/ace.clientside.syntax.highlighting.service';
+
+describe('AceClientsideSyntaxHighlightingService', () => {
+
+  let serviceUnderTest: AceClientsideSyntaxHighlightingService;
+
+  beforeEach(() => {
+    serviceUnderTest = new AceClientsideSyntaxHighlightingService();
+  });
+
+  it('throws exception for unknown language', () => {
+    // given
+    const unknownLanguageExtension = 'unknown';
+
+    // when
+    const actualExceptionReason = serviceUnderTest.getSyntaxHighlighting(unknownLanguageExtension)
+
+    // then
+    actualExceptionReason.then(response => fail(`expected exception, but got response: ${response}`))
+    .catch(actualReason => {
+      expect(actualReason).toEqual(`No syntax highlighting available for language extension "${unknownLanguageExtension}"`);
+    });
+  });
+
+  it('provides Ace syntax highlighting for known language', () => {
+    // given
+    const knownLanguageExtension = 'tcl';
+
+    // when
+    const actualExceptionReason = serviceUnderTest.getSyntaxHighlighting(knownLanguageExtension)
+
+    // then
+    actualExceptionReason.then(actualHighlighting => {
+      expect(actualHighlighting).toEqual('assets/xtext-resources/generated/mode-tcl');
+    }).catch(exceptionReason => fail(`unexpected exception: ${exceptionReason}`));
+  });
+});

--- a/src/service/syntaxHighlighting/syntax.highlighting.service.spec.ts
+++ b/src/service/syntaxHighlighting/syntax.highlighting.service.spec.ts
@@ -34,10 +34,10 @@ describe('AceClientsideSyntaxHighlightingService', () => {
 
     it(`provides Ace syntax highlighting file "${expectedSyntaxHighlightingFile}" for language "${knownLanguageExtension}"`, () => {
       // when
-      const actualExceptionReason = serviceUnderTest.getSyntaxHighlighting(knownLanguageExtension)
+      const syntaxHighlightingResult = serviceUnderTest.getSyntaxHighlighting(knownLanguageExtension)
 
       // then
-      actualExceptionReason.then(actualHighlighting => {
+      syntaxHighlightingResult.then(actualHighlighting => {
         expect(actualHighlighting).toEqual(expectedSyntaxHighlightingFile);
       }).catch(exceptionReason => fail(`unexpected exception: ${exceptionReason}`));
     });

--- a/src/service/syntaxHighlighting/syntax.highlighting.service.ts
+++ b/src/service/syntaxHighlighting/syntax.highlighting.service.ts
@@ -1,3 +1,3 @@
 export abstract class SyntaxHighlightingService {
-  abstract getSyntaxHighlighting(extension: string): Promise<any>;
+  abstract getSyntaxHighlighting(extension: string): Promise<string>;
 }

--- a/src/service/syntaxHighlighting/syntax.highlighting.service.ts
+++ b/src/service/syntaxHighlighting/syntax.highlighting.service.ts
@@ -1,0 +1,3 @@
+export abstract class SyntaxHighlightingService {
+  abstract getSyntaxHighlighting(extension: string): Promise<any>;
+}


### PR DESCRIPTION
Note: [mode-aml.js](https://github.com/test-editor/test-editor-web/compare/feature/syntax-highlighting?expand=1#diff-5147413ec008fd896d8cb162a7d64e65) and [mode-tcl.js](https://github.com/test-editor/test-editor-web/compare/feature/syntax-highlighting?expand=1#diff-bc5e9118482886a9e910dd191aa79f47) are auto-generated files, i.e. they shouldn't require a detailed review (unless we decide we want to customize the syntax highlighting rules by hand…)