### PR TITLE
Feature/navigator validation status proper

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@angular/platform-browser-dynamic": "^5.2.6",
     "@angular/router": "^5.2.6",
     "@testeditor/messaging-service": "^1.4.0",
-    "@testeditor/workspace-navigator": "~0.18.0",
+    "@testeditor/workspace-navigator": "~0.19.0",
     "ace-builds": "^1.3.1",
     "angular-auth-oidc-client": "^1.3.15",
     "angular2-jwt": "^0.2.3",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -8,12 +8,18 @@ import { AppComponent } from './app.component';
 import { AuthModule } from 'angular-auth-oidc-client';
 import { HttpModule } from '@angular/http';
 import { Routes, RouterModule } from '@angular/router'
+import { WorkspaceNavigatorModule, PersistenceService } from '@testeditor/workspace-navigator';
+import { mock, instance } from 'ts-mockito/lib/ts-mockito';
+import { ValidationMarkerService } from '../service/validation/validation.marker.service';
 
 const appRoutes: Routes = [
     { path: '', component: AppComponent }
   ]
 
 describe('AppComponent', () => {
+  const mockPersistenceService = mock(PersistenceService);
+  const mockValidationMarkerService = mock(ValidationMarkerService);
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -26,7 +32,11 @@ describe('AppComponent', () => {
       declarations: [
         AppComponent
       ],
-      providers: [{ provide: APP_BASE_HREF, useValue: '/' }]
+      providers: [
+        { provide: APP_BASE_HREF, useValue: '/' },
+        { provide: PersistenceService, useValue: instance(mockPersistenceService)},
+        { provide: ValidationMarkerService, useValue: instance(mockValidationMarkerService)}
+      ]
     }).compileComponents();
   }));
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -11,6 +11,7 @@ import { Routes, RouterModule } from '@angular/router'
 import { WorkspaceNavigatorModule, PersistenceService } from '@testeditor/workspace-navigator';
 import { mock, instance } from 'ts-mockito/lib/ts-mockito';
 import { ValidationMarkerService } from '../service/validation/validation.marker.service';
+import { DocumentService } from 'service/document/document.service';
 
 const appRoutes: Routes = [
     { path: '', component: AppComponent }
@@ -19,6 +20,7 @@ const appRoutes: Routes = [
 describe('AppComponent', () => {
   const mockPersistenceService = mock(PersistenceService);
   const mockValidationMarkerService = mock(ValidationMarkerService);
+  const mockDocumentService = mock(DocumentService);
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -35,7 +37,8 @@ describe('AppComponent', () => {
       providers: [
         { provide: APP_BASE_HREF, useValue: '/' },
         { provide: PersistenceService, useValue: instance(mockPersistenceService)},
-        { provide: ValidationMarkerService, useValue: instance(mockValidationMarkerService)}
+        { provide: ValidationMarkerService, useValue: instance(mockValidationMarkerService)},
+        { provide: DocumentService, useValue: instance(mockDocumentService)}
       ]
     }).compileComponents();
   }));

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -114,14 +114,4 @@ export class AppComponent {
       )))
     });
   }
-
-  private getAllDocuments(root: WorkspaceElement): Promise<any> {
-    if (root.children != null && root.children.length > 0) {
-      return root.children.reduce((previous, child) => previous.then(() => this.getAllDocuments(child)), Promise.resolve(root))
-        .then(() => root);
-    } else {
-      return this.documentService.loadDocument(root.path).then((response) => root['fulltext'] = response.text(),
-        (error) => Promise.resolve(root));
-    }
-  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,9 @@ import { Routes, RouterModule } from '@angular/router'
 
 import * as constants from './config/app-config';
 import { testEditorIndicatorFieldSetup } from './config/workspace.navigator.config';
+import { ValidationMarkerService } from 'service/validation/validation.marker.service';
+import { XtextDefaultValidationMarkerService } from '../service/validation/xtext.default.validation.marker.service';
+import { XtextDefaultValidationMarkerServiceConfig } from 'service/validation/xtext.default.validation.marker.service.config';
 
 const appRoutes: Routes = [
     { path: '', component: AppComponent }
@@ -51,7 +54,9 @@ export function authHttpServiceFactory(http: Http, options: RequestOptions) {
       provide: AuthHttp,
       useFactory: authHttpServiceFactory,
       deps: [Http, RequestOptions]
-    }
+    }, 
+    { provide: ValidationMarkerService, useClass: XtextDefaultValidationMarkerService },
+    { provide: XtextDefaultValidationMarkerServiceConfig, useValue: { serviceUrl: constants.appConfig.serviceUrls.xtextService }},
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,7 +16,7 @@ import * as constants from './config/app-config';
 import { testEditorIndicatorFieldSetup } from './config/workspace.navigator.config';
 import { ValidationMarkerService } from 'service/validation/validation.marker.service';
 import { XtextDefaultValidationMarkerService } from '../service/validation/xtext.default.validation.marker.service';
-import { XtextDefaultValidationMarkerServiceConfig } from 'service/validation/xtext.default.validation.marker.service.config';
+import { XtextValidationMarkerServiceConfig } from 'service/validation/xtext.validation.marker.service.config';
 
 const appRoutes: Routes = [
     { path: '', component: AppComponent }
@@ -25,8 +25,8 @@ const appRoutes: Routes = [
 export function authHttpServiceFactory(http: Http, options: RequestOptions) {
   return new AuthHttp(new AuthConfig({
     tokenName: 'token',
-		tokenGetter: (() => sessionStorage.getItem('token'))
-	}), http, options);
+    tokenGetter: (() => sessionStorage.getItem('token'))
+  }), http, options);
 }
 
 @NgModule({
@@ -54,9 +54,9 @@ export function authHttpServiceFactory(http: Http, options: RequestOptions) {
       provide: AuthHttp,
       useFactory: authHttpServiceFactory,
       deps: [Http, RequestOptions]
-    }, 
+    },
     { provide: ValidationMarkerService, useClass: XtextDefaultValidationMarkerService },
-    { provide: XtextDefaultValidationMarkerServiceConfig, useValue: { serviceUrl: constants.appConfig.serviceUrls.xtextService }},
+    { provide: XtextValidationMarkerServiceConfig, useValue: { serviceUrl: constants.appConfig.serviceUrls.validationMarkerService }},
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { AuthHttp, AuthConfig } from 'angular2-jwt';
 import { Routes, RouterModule } from '@angular/router'
 
 import * as constants from './config/app-config';
+import { testEditorIndicatorFieldSetup } from './config/workspace.navigator.config';
 
 const appRoutes: Routes = [
     { path: '', component: AppComponent }
@@ -39,7 +40,7 @@ export function authHttpServiceFactory(http: Http, options: RequestOptions) {
       persistenceServiceUrl: constants.appConfig.serviceUrls.persistenceService
     }, {
       testExecutionServiceUrl: constants.appConfig.serviceUrls.testExecutionService
-    }),
+    }, testEditorIndicatorFieldSetup),
     EditorTabsModule.forRoot({
       persistenceServiceUrl: constants.appConfig.serviceUrls.persistenceService,
     })

--- a/src/app/config/app-config.ts
+++ b/src/app/config/app-config.ts
@@ -2,6 +2,7 @@ export const appConfig = {
   "serviceUrls" : {
     "xtextService" : "http://localhost:8080/xtext-service",
     "persistenceService": "http://localhost:9080",
-    "testExecutionService": "http://localhost:9080/tests"
+    "testExecutionService": "http://localhost:9080/tests",
+    "validationMarkerService" : "http://localhost:8080/validation-markers"
   }
 };

--- a/src/app/config/workspace.navigator.config.ts
+++ b/src/app/config/workspace.navigator.config.ts
@@ -25,7 +25,7 @@ const testStatusField = {
 };
 
 const validationStatusField = {
-  condition: isFile,
+  condition: isValid,
   states: [{
     condition: hasValidationErrors,
     cssClasses: 'fa fa-exclamation-circle validation-errors',
@@ -46,7 +46,7 @@ export const testEditorIndicatorFieldSetup: IndicatorFieldSetup = {
 };
 
 export function isTclFile(element: WorkspaceElementInfo): boolean {
-  return element && element.name.endsWith('tcl');
+  return element && element.name.endsWith('.tcl');
 }
 
 export function testIsRunning(marker: any): boolean {
@@ -74,8 +74,8 @@ export function failedLabel(marker: any): string {
 }
 
 
-export function isFile(element: WorkspaceElementInfo) {
-  return element && element.type === ElementType.File;
+export function isValid(element: WorkspaceElementInfo) {
+  return element !== undefined;
 }
 
 export function hasValidationErrors(marker: any) {

--- a/src/app/config/workspace.navigator.config.ts
+++ b/src/app/config/workspace.navigator.config.ts
@@ -1,0 +1,118 @@
+import { ElementType, ElementState, IndicatorFieldSetup, WorkspaceElementInfo } from '@testeditor/workspace-navigator';
+
+/**
+ * Note: the Angular AOT compiler does not support function expressions in decorators,
+ * see e.g. https://github.com/angular/angular/issues/10789. Since the indicator field
+ * setup is included into the integration app's NgModule decorator, this is worked
+ * around by defining and exporting dedicated functions here.
+ */
+
+const testStatusField = {
+  condition: isTclFile,
+  states: [{
+    condition: testIsRunning,
+    cssClasses: 'fa fa-spinner fa-spin',
+    label: runningLabel,
+  }, {
+    condition: testHasSucceeded,
+    cssClasses: 'fa fa-circle test-success',
+    label: succeededLabel,
+  }, {
+    condition: testHasFailed,
+    cssClasses: 'fa fa-circle test-failure',
+    label: failedLabel,
+  }]
+};
+
+const validationStatusField = {
+  condition: isFile,
+  states: [{
+    condition: hasValidationErrors,
+    cssClasses: 'fa fa-exclamation-circle validation-errors',
+    label: validationStatusLabel
+  }, {
+    condition: hasValidationWarningsNoErrors,
+    cssClasses: 'fa fa-exclamation-triangle validation-warnings',
+    label: validationStatusLabel
+  }, {
+    condition: hasValidationInfosNoErrorsWarnings,
+    cssClasses: 'fa fa-info-circle validation-infos',
+    label: validationStatusLabel
+  }]
+}
+
+export const testEditorIndicatorFieldSetup: IndicatorFieldSetup = {
+  fields: [validationStatusField, testStatusField]
+};
+
+export function isTclFile(element: WorkspaceElementInfo): boolean {
+  return element && element.name.endsWith('tcl');
+}
+
+export function testIsRunning(marker: any): boolean {
+  return marker.testStatus === ElementState.Running;
+}
+
+export function testHasSucceeded(marker: any): boolean {
+  return marker.testStatus === ElementState.LastRunSuccessful;
+}
+
+export function testHasFailed(marker: any): boolean {
+  return marker.testStatus === ElementState.LastRunFailed;
+}
+
+export function runningLabel(marker: any): string {
+  return `Test "${marker.name}" is running`;
+}
+
+export function succeededLabel(marker: any): string {
+  return `Last run of test "${marker.name}" was successful`;
+}
+
+export function failedLabel(marker: any): string {
+  return `Last run of test "${marker.name}" has failed`;
+}
+
+
+export function isFile(element: WorkspaceElementInfo) {
+  return element && element.type === ElementType.File;
+}
+
+export function hasValidationErrors(marker: any) {
+  return isValidationMarker(marker) && marker.validation.errors > 0;
+}
+
+export function hasValidationWarningsNoErrors(marker: any) {
+  return isValidationMarker(marker) && marker.validation.errors <= 0 && marker.validation.warnings > 0;
+}
+
+export function hasValidationInfosNoErrorsWarnings(marker: any) {
+  return isValidationMarker(marker) && marker.validation.errors <= 0
+    && marker.validation.warnings <= 0 && marker.validation.infos > 0;
+}
+
+export function validationStatusLabel(marker: any): string {
+  let label = '';
+  if (isValidationMarker(marker)) {
+    if (marker.validation.errors > 0) {
+      label += `${marker.validation.errors} error(s)`;
+    }
+    if (marker.validation.warnings > 0) {
+      if (label.length > 0) {
+        label += ', ';
+      }
+      label += `${marker.validation.warnings} warning(s)`
+    }
+    if (marker.validation.infos > 0) {
+      if (label.length > 0) {
+        label += ', ';
+      }
+      label += `${marker.validation.infos} info(s)`
+    }
+  }
+  return label;
+}
+
+function isValidationMarker(marker: any): boolean {
+  return marker != null && marker.validation != null;
+}

--- a/src/service/validation/validation.marker.service.spec.ts
+++ b/src/service/validation/validation.marker.service.spec.ts
@@ -1,0 +1,210 @@
+import { TestBed, inject } from '@angular/core/testing';
+import { HttpModule, XHRBackend, RequestMethod, Response, ResponseOptions } from '@angular/http';
+import { MockBackend, MockConnection } from '@angular/http/testing';
+import { AuthConfig, AuthHttp } from 'angular2-jwt';
+import { XtextDefaultValidationMarkerServiceConfig } from './xtext.default.validation.marker.service.config';
+import { ElementType, WorkspaceElement } from '@testeditor/workspace-navigator';
+import { mock } from 'ts-mockito/lib/ts-mockito';
+import { ValidationMarkerService, ValidationSummary } from './validation.marker.service';
+import { XtextDefaultValidationMarkerService } from './xtext.default.validation.marker.service';
+import { async } from '@angular/core/testing';
+
+describe('ValidationMarkerService', () => {
+
+  beforeEach(() => {
+    const serviceConfig: XtextDefaultValidationMarkerServiceConfig = {
+      serviceUrl: ''
+    }
+
+    // dummy jwt token
+    const authToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M';
+
+    TestBed.configureTestingModule({
+      imports: [HttpModule],
+      providers: [
+        { provide: XHRBackend, useClass: MockBackend},
+        { provide: AuthConfig, useValue: new AuthConfig({tokenGetter: () => authToken}) },
+        { provide: XtextDefaultValidationMarkerServiceConfig, useValue: serviceConfig },
+        { provide: ValidationMarkerService, useClass: XtextDefaultValidationMarkerService},
+        AuthHttp
+      ]
+    });
+  });
+
+  it('retrieves markers for single file', async(inject([XHRBackend, ValidationMarkerService],
+    (backend: MockBackend, validationMarkerService: ValidationMarkerService) => {
+    // given
+    const sampleFile: WorkspaceElement = { path: 'sample/path/file.txt', name: 'file.txt', children: [], type: ElementType.File };
+    backend.connections.subscribe((connection: MockConnection) => {
+      connection.mockRespond(new Response(new ResponseOptions({
+        status: 200,
+        body: sampleResponseBody
+      })));
+    })
+
+    // when
+    validationMarkerService.getMarkerSummary(sampleFile).then((summaries: ValidationSummary[]) => {
+
+    // then
+    expect(summaries.length).toEqual(1);
+    expect(summaries[0].path).toEqual(sampleFile.path);
+    expect(summaries[0].errors).toEqual(3);
+    expect(summaries[0].warnings).toEqual(2);
+    expect(summaries[0].infos).toEqual(6);
+  });
+  })));
+
+  it('retrieves markers for multiple (nested) files and folders', async(inject([XHRBackend, ValidationMarkerService],
+    (backend: MockBackend, validationMarkerService: ValidationMarkerService) => {
+    // given
+    backend.connections.subscribe((connection: MockConnection) => {
+      connection.mockRespond(new Response(new ResponseOptions({
+        status: 200,
+        body: sampleResponseBody
+      })));
+    })
+
+    // when
+    validationMarkerService.getMarkerSummary(root).then((summaries: ValidationSummary[]) => {
+
+    // then
+    expect(summaries).toEqual(expectedValidationMarkersForSampleResponse);
+    console.log(JSON.stringify(summaries));
+  });
+  })));
+
+  it('handles errors in responses gracefully', async(inject([XHRBackend, ValidationMarkerService],
+    (backend: MockBackend, validationMarkerService: ValidationMarkerService) => {
+    // given
+    let connectionCounter = 0;
+    backend.connections.subscribe((connection: MockConnection) => {
+      if (connectionCounter++ % 2) {
+        connection.mockRespond(new Response(new ResponseOptions({
+          status: 200,
+          body: sampleResponseBody
+        })));
+      } else {
+        connection.mockError(new Error('Error while requesting validation markers'));
+      }
+    })
+
+    // when
+    validationMarkerService.getMarkerSummary(root).then((summaries: ValidationSummary[]) => {
+
+    // then
+    expect(summaries.sort()).toEqual(expectedValdationMarkersWithErrors.sort());
+    console.log(JSON.stringify(summaries));
+  });
+  })));
+
+  [undefined, null, '', '{ issues:'].forEach((malformedBody) => {
+    it(`handles malformed bodies ("${malformedBody}") in responses gracefully`, async(inject([XHRBackend, ValidationMarkerService],
+      (backend: MockBackend, validationMarkerService: ValidationMarkerService) => {
+      // given
+      const sampleFile: WorkspaceElement = { path: 'sample/path/file.txt', name: 'file.txt', children: [], type: ElementType.File };
+      backend.connections.subscribe((connection: MockConnection) => {
+        connection.mockRespond(new Response(new ResponseOptions({
+          status: 200,
+          body: null
+        })));
+      })
+
+      // when
+      validationMarkerService.getMarkerSummary(sampleFile).then((summaries: ValidationSummary[]) => {
+
+      // then
+        expect(summaries.length).toEqual(1);
+        expect(summaries[0].path).toEqual(sampleFile.path);
+        expect(summaries[0].errors).toEqual(0);
+        expect(summaries[0].warnings).toEqual(0);
+        expect(summaries[0].infos).toEqual(0);
+      });
+    })));
+  });
+
+  const sampleResponseBody = '{"issues":[\
+    {"description":"WebBrowser cannot be resolved.","severity":"error","line":19,"column":13,"offset":553,"length":10},\
+    {"description":"WebBrowser cannot be resolved.","severity":"error","line":33,"column":13,"offset":925,"length":10},\
+    {"description":"component/mask is not defined in aml","severity":"warning","line":19,"column":13,"offset":553,"length":10},\
+    {"description":"test step could not resolve fixture","severity":"info","line":20,"column":4,"offset":567,"length":5},\
+    {"description":"No ComponentElement found.","severity":"error","line":20,"column":10,"offset":573,"length":9},\
+    {"description":"test step could not resolve fixture","severity":"info","line":21,"column":4,"offset":586,"length":6},\
+    {"description":"test step could not resolve fixture","severity":"info","line":25,"column":4,"offset":709,"length":4},\
+    {"description":"test step could not resolve fixture","severity":"info","line":29,"column":12,"offset":815,"length":3},\
+    {"description":"component/mask is not defined in aml","severity":"warning","line":33,"column":13,"offset":925,"length":10},\
+    {"description":"test step could not resolve fixture","severity":"info","line":34,"column":4,"offset":939,"length":4},\
+    {"description":"test step could not resolve fixture","severity":"info","line":35,"column":4,"offset":961,"length":5}]}';
+
+  const firstChild: WorkspaceElement = {
+    name: 'firstChild',
+    path: 'root/firstChild',
+    type: ElementType.File,
+    children: []
+  };
+  const greatGrandChild1: WorkspaceElement = {
+    name: 'greatGrandChild1',
+    path: 'root/middleChild/grandChild/greatGrandChild1',
+    type: ElementType.File,
+    children: []
+  };
+  const greatGrandChild2: WorkspaceElement = {
+    name: 'greatGrandChild2',
+    path: 'root/middleChild/grandChild/greatGrandChild2',
+    type: ElementType.File,
+    children: []
+  };
+  const grandChild: WorkspaceElement = {
+    name: 'grandChild',
+    path: 'root/middleChild/grandChild',
+    type: ElementType.Folder,
+    children: [greatGrandChild1, greatGrandChild2]
+  };
+  const middleChild: WorkspaceElement = {
+    name: 'middleChild',
+    path: 'root/middleChild',
+    type: ElementType.Folder,
+    children: [grandChild]
+  };
+  const lastChild: WorkspaceElement = {
+    name: 'lastChild',
+    path: 'root/lastChild',
+    type: ElementType.File,
+    children: []
+  };
+
+   /**
+   * + root
+   *   - firstChild
+   *   + middleChild
+   *     + grandChild
+   *       - greatGrandChild1
+   *       - greatGrandChild2
+   *   - lastChild
+   */
+  const root: WorkspaceElement = {
+    name: 'folder',
+    path: 'root',
+    type: ElementType.Folder,
+    children: [firstChild, middleChild, lastChild],
+  };
+
+  const expectedValidationMarkersForSampleResponse = [
+    {path: firstChild.path, errors: 3, warnings: 2, infos: 6},
+    {path: greatGrandChild1.path, errors: 3, warnings: 2, infos: 6},
+    {path: greatGrandChild2.path, errors: 3, warnings: 2, infos: 6},
+    {path: grandChild.path, errors: 6, warnings: 4, infos: 12},
+    {path: middleChild.path, errors: 6, warnings: 4, infos: 12},
+    {path: lastChild.path, errors: 3, warnings: 2, infos: 6},
+    {path: root.path, errors: 12, warnings: 8, infos: 24},
+  ]
+
+  const expectedValdationMarkersWithErrors = [
+    {path: firstChild.path, errors: 0, warnings: 0, infos: 0},
+    {path: greatGrandChild1.path, errors: 3, warnings: 2, infos: 6},
+    {path: greatGrandChild2.path, errors: 0, warnings: 0, infos: 0},
+    {path: grandChild.path, errors: 3, warnings: 2, infos: 6},
+    {path: middleChild.path, errors: 3, warnings: 2, infos: 6},
+    {path: lastChild.path, errors: 3, warnings: 2, infos: 6},
+    {path: root.path, errors: 6, warnings: 4, infos: 12},
+  ]
+});

--- a/src/service/validation/validation.marker.service.spec.ts
+++ b/src/service/validation/validation.marker.service.spec.ts
@@ -2,17 +2,17 @@ import { TestBed, inject } from '@angular/core/testing';
 import { HttpModule, XHRBackend, RequestMethod, Response, ResponseOptions } from '@angular/http';
 import { MockBackend, MockConnection } from '@angular/http/testing';
 import { AuthConfig, AuthHttp } from 'angular2-jwt';
-import { XtextDefaultValidationMarkerServiceConfig } from './xtext.default.validation.marker.service.config';
+import { XtextValidationMarkerServiceConfig } from './xtext.validation.marker.service.config';
 import { ElementType, WorkspaceElement } from '@testeditor/workspace-navigator';
 import { mock } from 'ts-mockito/lib/ts-mockito';
 import { ValidationMarkerService, ValidationSummary } from './validation.marker.service';
-import { XtextDefaultValidationMarkerService } from './xtext.default.validation.marker.service';
+import { XtextNaiveValidationMarkerService } from './xtext.naive.validation.marker.service';
 import { async } from '@angular/core/testing';
 
 describe('ValidationMarkerService', () => {
 
   beforeEach(() => {
-    const serviceConfig: XtextDefaultValidationMarkerServiceConfig = {
+    const serviceConfig: XtextValidationMarkerServiceConfig = {
       serviceUrl: ''
     }
 
@@ -24,8 +24,8 @@ describe('ValidationMarkerService', () => {
       providers: [
         { provide: XHRBackend, useClass: MockBackend},
         { provide: AuthConfig, useValue: new AuthConfig({tokenGetter: () => authToken}) },
-        { provide: XtextDefaultValidationMarkerServiceConfig, useValue: serviceConfig },
-        { provide: ValidationMarkerService, useClass: XtextDefaultValidationMarkerService},
+        { provide: XtextValidationMarkerServiceConfig, useValue: serviceConfig },
+        { provide: ValidationMarkerService, useClass: XtextNaiveValidationMarkerService},
         AuthHttp
       ]
     });
@@ -43,7 +43,7 @@ describe('ValidationMarkerService', () => {
     })
 
     // when
-    validationMarkerService.getMarkerSummary(sampleFile).then((summaries: ValidationSummary[]) => {
+    validationMarkerService.getAllMarkerSummaries(sampleFile).then((summaries: ValidationSummary[]) => {
 
     // then
     expect(summaries.length).toEqual(1);
@@ -65,7 +65,7 @@ describe('ValidationMarkerService', () => {
     })
 
     // when
-    validationMarkerService.getMarkerSummary(root).then((summaries: ValidationSummary[]) => {
+    validationMarkerService.getAllMarkerSummaries(root).then((summaries: ValidationSummary[]) => {
 
     // then
     expect(summaries).toEqual(expectedValidationMarkersForSampleResponse);
@@ -89,7 +89,7 @@ describe('ValidationMarkerService', () => {
     })
 
     // when
-    validationMarkerService.getMarkerSummary(root).then((summaries: ValidationSummary[]) => {
+    validationMarkerService.getAllMarkerSummaries(root).then((summaries: ValidationSummary[]) => {
 
     // then
     expect(summaries.sort()).toEqual(expectedValdationMarkersWithErrors.sort());
@@ -110,7 +110,7 @@ describe('ValidationMarkerService', () => {
       })
 
       // when
-      validationMarkerService.getMarkerSummary(sampleFile).then((summaries: ValidationSummary[]) => {
+      validationMarkerService.getAllMarkerSummaries(sampleFile).then((summaries: ValidationSummary[]) => {
 
       // then
         expect(summaries.length).toEqual(1);

--- a/src/service/validation/validation.marker.service.spec.ts
+++ b/src/service/validation/validation.marker.service.spec.ts
@@ -16,14 +16,13 @@ describe('ValidationMarkerService', () => {
       serviceUrl: ''
     }
 
-    // dummy jwt token
-    const authToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M';
+    const dummyAuthToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M';
 
     TestBed.configureTestingModule({
       imports: [HttpModule],
       providers: [
         { provide: XHRBackend, useClass: MockBackend},
-        { provide: AuthConfig, useValue: new AuthConfig({tokenGetter: () => authToken}) },
+        { provide: AuthConfig, useValue: new AuthConfig({tokenGetter: () => dummyAuthToken}) },
         { provide: XtextValidationMarkerServiceConfig, useValue: serviceConfig },
         { provide: ValidationMarkerService, useClass: XtextNaiveValidationMarkerService},
         AuthHttp
@@ -43,15 +42,16 @@ describe('ValidationMarkerService', () => {
     })
 
     // when
-    validationMarkerService.getAllMarkerSummaries(sampleFile).then((summaries: ValidationSummary[]) => {
+    validationMarkerService.getAllMarkerSummaries(sampleFile)
 
     // then
-    expect(summaries.length).toEqual(1);
-    expect(summaries[0].path).toEqual(sampleFile.path);
-    expect(summaries[0].errors).toEqual(3);
-    expect(summaries[0].warnings).toEqual(2);
-    expect(summaries[0].infos).toEqual(6);
-  });
+    .then((summaries: ValidationSummary[]) => {
+      expect(summaries.length).toEqual(1);
+      expect(summaries[0].path).toEqual(sampleFile.path);
+      expect(summaries[0].errors).toEqual(3);
+      expect(summaries[0].warnings).toEqual(2);
+      expect(summaries[0].infos).toEqual(6);
+    });
   })));
 
   it('retrieves markers for multiple (nested) files and folders', async(inject([XHRBackend, ValidationMarkerService],
@@ -65,12 +65,12 @@ describe('ValidationMarkerService', () => {
     })
 
     // when
-    validationMarkerService.getAllMarkerSummaries(root).then((summaries: ValidationSummary[]) => {
+    validationMarkerService.getAllMarkerSummaries(root)
 
     // then
-    expect(summaries).toEqual(expectedValidationMarkersForSampleResponse);
-    console.log(JSON.stringify(summaries));
-  });
+    .then((summaries: ValidationSummary[]) => {
+      expect(summaries).toEqual(expectedValidationMarkersForSampleResponse);
+    });
   })));
 
   it('handles errors in responses gracefully', async(inject([XHRBackend, ValidationMarkerService],
@@ -86,14 +86,14 @@ describe('ValidationMarkerService', () => {
       } else {
         connection.mockError(new Error('Error while requesting validation markers'));
       }
-    })
+    });
 
     // when
     validationMarkerService.getAllMarkerSummaries(root).then((summaries: ValidationSummary[]) => {
 
     // then
+    expect(connectionCounter).toEqual(numberOfWorkspaceLeafs);
     expect(summaries.sort()).toEqual(expectedValdationMarkersWithErrors.sort());
-    console.log(JSON.stringify(summaries));
   });
   })));
 
@@ -187,6 +187,8 @@ describe('ValidationMarkerService', () => {
     type: ElementType.Folder,
     children: [firstChild, middleChild, lastChild],
   };
+
+  const numberOfWorkspaceLeafs = 4;
 
   const expectedValidationMarkersForSampleResponse = [
     {path: firstChild.path, errors: 3, warnings: 2, infos: 6},

--- a/src/service/validation/validation.marker.service.ts
+++ b/src/service/validation/validation.marker.service.ts
@@ -1,12 +1,12 @@
 import { WorkspaceElement } from '@testeditor/workspace-navigator';
 
 export abstract class ValidationMarkerService {
-  abstract getMarkerSummary(workspaceRoot: WorkspaceElement): Promise<ValidationSummary[]>;
+  abstract getAllMarkerSummaries(workspaceRoot: WorkspaceElement): Promise<ValidationSummary[]>;
 }
 
 export interface ValidationSummary {
   path: string,
   errors: number,
   warnings: number,
-   infos: number
+  infos: number
 }

--- a/src/service/validation/validation.marker.service.ts
+++ b/src/service/validation/validation.marker.service.ts
@@ -1,0 +1,12 @@
+import { WorkspaceElement } from '@testeditor/workspace-navigator';
+
+export abstract class ValidationMarkerService {
+  abstract getMarkerSummary(workspaceRoot: WorkspaceElement): Promise<ValidationSummary[]>;
+}
+
+export interface ValidationSummary {
+  path: string,
+  errors: number,
+  warnings: number,
+   infos: number
+}

--- a/src/service/validation/xtext.default.validation.marker.service.config.ts
+++ b/src/service/validation/xtext.default.validation.marker.service.config.ts
@@ -1,3 +1,0 @@
-export class XtextDefaultValidationMarkerServiceConfig {
-  serviceUrl: string;
-}

--- a/src/service/validation/xtext.default.validation.marker.service.config.ts
+++ b/src/service/validation/xtext.default.validation.marker.service.config.ts
@@ -1,0 +1,3 @@
+export class XtextDefaultValidationMarkerServiceConfig {
+  serviceUrl: string;
+}

--- a/src/service/validation/xtext.default.validation.marker.service.ts
+++ b/src/service/validation/xtext.default.validation.marker.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@angular/core';
+import { AuthHttp } from 'angular2-jwt';
+import { ValidationMarkerService, ValidationSummary } from './validation.marker.service';
+import { WorkspaceElement } from '@testeditor/workspace-navigator';
+import { XtextDefaultValidationMarkerServiceConfig } from './xtext.default.validation.marker.service.config';
+
+/**
+ * This is a naive implementation using the REST endpoint for validation information
+ * already provided by Xtext. This endpoint, however, provides more detailed information
+ * on a per-file basis, and is therefore not well-suited to retrieve only a summary of
+ * validation markers present on all files. This is a fallback that should be expected
+ * to perform poorly.
+*/
+@Injectable()
+export class XtextDefaultValidationMarkerService extends ValidationMarkerService {
+
+  private serviceUrl: string;
+
+  constructor(private http: AuthHttp, config: XtextDefaultValidationMarkerServiceConfig) {
+    super();
+    this.serviceUrl = config.serviceUrl;
+  }
+
+  getMarkerSummary(root: WorkspaceElement): Promise<ValidationSummary[]> {
+    if (root.children != null && root.children.length > 0) {
+      return root.children.reduce((accumulatorPromise: Promise<ValidationSummaryAccumulator>, child: WorkspaceElement) => {
+        return accumulatorPromise.then((accumulator) => {
+          return this.getMarkerSummary(child).then((childSummaries) => {
+            // console.log(`ValidationSummaries for "${child.path}" are: ${JSON.stringify(childSummaries)}`);
+            // console.log(`ValidationSummary of parent "${root.path}" is: ${JSON.stringify(accumulator.parentSummary)}`);
+            accumulator.summaries = accumulator.summaries.concat(childSummaries);
+            const childSummary = childSummaries.find((summary) => summary.path === child.path)
+            accumulator.parentSummary.errors += childSummary.errors
+            accumulator.parentSummary.warnings += childSummary.warnings
+            accumulator.parentSummary.infos += childSummary.infos
+            return accumulator;
+          });
+        });
+      }, Promise.resolve({
+        lastResponse: [],
+        summaries: [],
+        parentSummary: { path: root.path, errors: 0, warnings: 0, infos: 0 }
+      } as ValidationSummaryAccumulator)).then((accumulatedSummaries: ValidationSummaryAccumulator) =>
+        accumulatedSummaries.summaries.concat([accumulatedSummaries.parentSummary]));
+    } else {
+      return this.getMarkersForFile(root.path);
+    }
+  }
+
+  private getMarkersForFile(path: string): Promise<ValidationSummary[]> {
+    const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+    return this.http.get(`${this.serviceUrl}?resource=${encodedPath}`).toPromise().then((response) => {
+      try {
+        const validationResponse: ValidationServiceResponseType = response.json();
+        return [{
+          path: path,
+          errors: validationResponse.issues.filter(issue => issue.severity === Severity.ERROR).length,
+          warnings: validationResponse.issues.filter(issue => issue.severity === Severity.WARNING).length,
+          infos: validationResponse.issues.filter(issue => issue.severity === Severity.INFO).length,
+        }]
+      } catch (error) {
+        return this.logErrorAndAssumeDefault(path, error);
+      }
+    }, (rejected) => this.logErrorAndAssumeDefault(path, rejected));
+  }
+
+  private logErrorAndAssumeDefault(path: string, error: any): ValidationSummary[] {
+    console.log(`An error occurred while trying to retrieve validation markers for "${path}": ${error}`);
+    return [{path: path, errors: 0, warnings: 0, infos: 0}];
+  }
+
+}
+
+enum Severity { ERROR = 'error', WARNING = 'warning', INFO = 'info'}
+
+interface ValidationServiceResponseType {
+  issues: {
+    severity: Severity
+  }[]
+}
+
+interface ValidationSummaryAccumulator {
+  summaries: ValidationSummary[],
+  parentSummary: ValidationSummary
+}
+
+function isValidationServiceResponseType(response: any): response is ValidationServiceResponseType {
+  return response != null && response.issues != null && response.issues.every((issue) => issue.severity != null);
+}

--- a/src/service/validation/xtext.naive.validation.marker.service.ts
+++ b/src/service/validation/xtext.naive.validation.marker.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from '@angular/core';
+import { Headers } from '@angular/http';
+import { AuthHttp } from 'angular2-jwt';
+import { ValidationMarkerService, ValidationSummary } from './validation.marker.service';
+import { WorkspaceElement } from '@testeditor/workspace-navigator';
+import { XtextValidationMarkerServiceConfig } from './xtext.validation.marker.service.config';
+import { ElementType } from '@testeditor/workspace-navigator';
+
+/**
+ * This is a naive implementation using the REST endpoint for validation information
+ * already provided by Xtext. This endpoint, however, provides more detailed information
+ * on a per-file basis, and is therefore not well-suited to retrieve only a summary of
+ * validation markers present on all files. This is a fallback that should be expected
+ * to perform poorly.
+*/
+@Injectable()
+export class XtextNaiveValidationMarkerService extends ValidationMarkerService {
+
+  private serviceUrl: string;
+
+  constructor(private http: AuthHttp, config: XtextValidationMarkerServiceConfig) {
+    super();
+    this.serviceUrl = config.serviceUrl;
+  }
+
+  getAllMarkerSummaries(root: WorkspaceElement): Promise<ValidationSummary[]> {
+    if (root.children != null && root.children.length > 0) {
+      return root.children.reduce((accumulatorPromise: Promise<ValidationSummaryAccumulator>, child: WorkspaceElement) => {
+        return accumulatorPromise.then((accumulator) => {
+          return this.getAllMarkerSummaries(child).then((childSummaries) => {
+            accumulator.summaries = accumulator.summaries.concat(childSummaries);
+            const childSummary = childSummaries.find((summary) => summary.path === child.path)
+            accumulator.parentSummary.errors += childSummary.errors
+            accumulator.parentSummary.warnings += childSummary.warnings
+            accumulator.parentSummary.infos += childSummary.infos
+            return accumulator;
+          });
+        });
+      }, Promise.resolve({
+        lastResponse: [],
+        summaries: [],
+        parentSummary: { path: root.path, errors: 0, warnings: 0, infos: 0 }
+      } as ValidationSummaryAccumulator)).then((accumulatedSummaries: ValidationSummaryAccumulator) =>
+        accumulatedSummaries.summaries.concat([accumulatedSummaries.parentSummary]));
+    } else {
+      return this.getMarkersForFile(root);
+    }
+  }
+
+  private getMarkersForFile(root: WorkspaceElement): Promise<ValidationSummary[]> {
+    const httpOptions = {
+      headers: new Headers({
+        'Content-Type':  'application/x-www-form-urlencoded; charset=UTF-8'
+      })
+    };
+    const fulltext = encodeURIComponent(root['fulltext']).replace(/%20/g, '+');
+    return this.http.post(`${this.serviceUrl}/validate?resource=${encodeURIComponent(root.path)}`,
+      `fullText=${fulltext}`, httpOptions).toPromise().then((response) => {
+      try {
+        const validationResponse: ValidationServiceResponseType = response.json();
+        return [{
+          path: root.path,
+          errors: validationResponse.issues.filter(issue => issue.severity === Severity.ERROR).length,
+          warnings: validationResponse.issues.filter(issue => issue.severity === Severity.WARNING).length,
+          infos: validationResponse.issues.filter(issue => issue.severity === Severity.INFO).length,
+        }]
+      } catch (error) {
+        return this.logErrorAndAssumeDefault(root.path, error);
+      }
+    }, (rejected) => this.logErrorAndAssumeDefault(root.path, rejected));
+  }
+
+  private logErrorAndAssumeDefault(path: string, error: any): ValidationSummary[] {
+    console.log(`An error occurred while trying to retrieve validation markers for "${path}": ${error}`);
+    return [{path: path, errors: 0, warnings: 0, infos: 0}];
+  }
+
+}
+
+enum Severity { ERROR = 'error', WARNING = 'warning', INFO = 'info'}
+
+interface ValidationServiceResponseType {
+  issues: {
+    severity: Severity
+  }[]
+}
+
+interface ValidationSummaryAccumulator {
+  summaries: ValidationSummary[],
+  parentSummary: ValidationSummary
+}
+
+function isValidationServiceResponseType(response: any): response is ValidationServiceResponseType {
+  return response != null && response.issues != null && response.issues.every((issue) => issue.severity != null);
+}

--- a/src/service/validation/xtext.validation.marker.service.config.ts
+++ b/src/service/validation/xtext.validation.marker.service.config.ts
@@ -1,0 +1,3 @@
+export class XtextValidationMarkerServiceConfig {
+  serviceUrl: string;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,21 @@
 /* You can add global styles to this file, and also import other style files */
+
+.test-success {
+  color: #23d800;
+}
+
+.test-failure {
+  color: #d82300
+}
+
+.validation-errors {
+  color: #d82300
+}
+
+.validation-warnings {
+  color: #ffcc00
+}
+
+.validation-infos {
+  color: #3498DB
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,9 +198,9 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@testeditor/messaging-service/-/messaging-service-1.4.0.tgz#a6ea5de45b1b59c8f0ecdb5af99b2899fb17d3e7"
 
-"@testeditor/workspace-navigator@~0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@testeditor/workspace-navigator/-/workspace-navigator-0.18.0.tgz#0f6c4bfa4bcb6a6f0bd8cd35c818e4e84369d107"
+"@testeditor/workspace-navigator@~0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@testeditor/workspace-navigator/-/workspace-navigator-0.19.0.tgz#5c376c4a94dc69fa33dbc963889be78d3868b22a"
 
 "@types/jasmine@2.8.6":
   version "2.8.6"


### PR DESCRIPTION
1. uses updated workspace navigator's marker indicator features to setup test and validation status display 
2. introduces service to retrieve validation markers (naive implementation using Xtext's existing validation REST endpoint, as well as the newer, default implementation relying on a dedicated validation marker endpoint)