### PR TITLE
allow for linking web workspace navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,63 @@ Understands the following events:
 </pre></td>
   </tr>
 </table>
+
+## Linking local web-workspace-navigator into node_modules
+
+In order to work with non published artifacts of web-workspace-navigator within the test-editor-web, linking can be used.
+Given the following variables, this are the steps to have functional linking in place without modifying any sources.
+TODO: if deemed useful these steps should be put into scripts.
+
+``` shell
+WORKSPACE_NAVIGATOR="~/path/to/project"
+TEST_EDITOR_WEB="~/path/to/project"
+PREFIX=`npm prefix -g`
+```
+
+### bring linking into place
+
+``` shell
+cd $WORKSPACE_NAVIGATOR
+npm link
+cd $TEST_EDITOR_WEB
+npm link @testeditor/workspace-navigator
+cd $PREFIX/lib/node_modules/@testeditor
+rm workspace-navigator # old linking
+ln -s $WORKSPACE_NAVIGATOR/out-tsc/lib-es5/ workspace-navigator # new linking
+# check the link
+ls $TEST_EDITOR_WEB/node_modules/@testeditor/workspace-navigator
+```
+
+### build web-workspace-navigator initially
+
+``` shell
+cd $WORKSPACE_NAVIGATOR # only if not already there
+npm run build
+```
+
+### build and serve test-editor-web
+
+``` shell
+cd $TEST_EDITOR_WEB # only if not already there
+npm run start
+```
+
+
+### make changes to web-workspace-navigator
+
+``` shell
+cd $WORKSPACE_NAVIGATOR # only if not already there
+node build.js 
+```
+
+`node build.js` will not cleanup all old resources, so this works only for some changes, in all other cases use `npm run build`. If `npm run build` is run, the test editor web needs to be restarted!
+
+### undo linking and restore original modules
+
+``` shell
+rm $PREFIX/lib/node_modules/@testeditor/workspace-navigator
+cd $TEST_EDITOR_WEB
+rm node_modules/@testeditor/workspace-navigator
+yarn install --force
+npm run build
+```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "EPL",
   "scripts": {
     "ng": "node_modules/@angular/cli/bin/ng",
-    "start": "ng serve -H 0.0.0.0",
+    "start": "ng serve -H 0.0.0.0 --preserve-symlinks",
     "build": "ng lint && ng build",
     "test": "ng test",
     "testCIChrome": "ng test --browser ChromeHeadless --single-run --log-level debug",
@@ -24,7 +24,7 @@
     "@angular/platform-browser-dynamic": "^5.2.6",
     "@angular/router": "^5.2.6",
     "@testeditor/messaging-service": "^1.4.0",
-    "@testeditor/workspace-navigator": "~0.21.0",
+    "@testeditor/workspace-navigator": "~0.22.0",
     "ace-builds": "^1.3.1",
     "angular-auth-oidc-client": "^1.3.15",
     "angular2-jwt": "^0.2.3",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,11 +6,10 @@ import { NAVIGATION_CLOSE, EDITOR_SAVE_COMPLETED } from './editor-tabs/event-typ
 
 import { TEST_EXECUTION_START_FAILED, TEST_EXECUTION_STARTED, TEST_EXECUTE_REQUEST,
          WORKSPACE_MARKER_OBSERVE, WORKSPACE_MARKER_UPDATE, WORKSPACE_RELOAD_RESPONSE, WORKSPACE_RELOAD_REQUEST,
-         PersistenceService, WorkspaceElement } from '@testeditor/workspace-navigator';
+         PersistenceService, WorkspaceElement, MarkerObserver } from '@testeditor/workspace-navigator';
 import { ValidationMarkerService } from 'service/validation/validation.marker.service';
 import { IndexService } from '../service/index/index.service';
 import { TestExecutionService, TestExecutionStatus } from 'service/execution/test.execution.service';
-import { MarkerObserver } from '@testeditor/workspace-navigator/src/common/markers/marker.observer';
 import { TestExecutionState } from '../service/execution/test.execution.state';
 
 @Component({

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,9 +198,11 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@testeditor/messaging-service/-/messaging-service-1.4.0.tgz#a6ea5de45b1b59c8f0ecdb5af99b2899fb17d3e7"
 
-"@testeditor/workspace-navigator@~0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@testeditor/workspace-navigator/-/workspace-navigator-0.21.0.tgz#9b02f550849408eb8f8d6dcea0638b87f0030bd9"
+"@testeditor/workspace-navigator@~0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@testeditor/workspace-navigator/-/workspace-navigator-0.22.0.tgz#7165faa1fccf94af10960348189b38a611fdec99"
+  dependencies:
+    yarn "^1.5.1"
 
 "@types/jasmine@2.8.6":
   version "2.8.6"
@@ -7170,6 +7172,10 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yarn@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.5.1.tgz#e8680360e832ac89521eb80dad3a7bc27a40bab4"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
- new web workspace navigator version (which export marker.observer)
- ng serve now uses --preserve-symlinks
- readme lists necessary steps to get linking in place