### PR TITLE
include testexec-navigator in test-editor-web

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-browser-dynamic": "^5.2.10",
     "@angular/router": "^5.2.10",
     "@testeditor/messaging-service": "^1.4.0",
+    "@testeditor/testexec-navigator": "^0.2.11",
     "@testeditor/workspace-navigator": "~0.26.0",
     "ace-builds": "^1.3.3",
     "angular-auth-oidc-client": "^4.1.0",

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -3,7 +3,7 @@
   height: 100vh;
 }
 
-#editor-area {
+#editor-area, #test-area {
   flex-grow: 1;
   height: 100%;
   width: 100%;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,4 +11,7 @@
   <div id="editor-area">
     <app-editor-tabs></app-editor-tabs>
   </div>
+  <div id="test-area">
+    <app-navigator></app-navigator>
+  </div>
 </div>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,7 @@ import { ModalModule } from 'ngx-bootstrap/modal';
 
 import { MessagingModule } from '@testeditor/messaging-service';
 import { WorkspaceNavigatorModule } from '@testeditor/workspace-navigator';
+import { NavigatorModule } from '@testeditor/testexec-navigator';
 
 import { AppComponent } from './app.component';
 import { EditorTabsModule } from './editor-tabs/editor-tabs.module';
@@ -39,6 +40,7 @@ const appRoutes: Routes = [
     ModalDialogComponent
   ],
   imports: [
+    NavigatorModule,
     BrowserModule,
     HttpClientModule,
     ModalModule.forRoot(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,6 +198,12 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@testeditor/messaging-service/-/messaging-service-1.4.0.tgz#a6ea5de45b1b59c8f0ecdb5af99b2899fb17d3e7"
 
+"@testeditor/testexec-navigator@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@testeditor/testexec-navigator/-/testexec-navigator-0.2.11.tgz#e5ceabccbb16379a7498ac79f4c4766ddc4d537c"
+  dependencies:
+    tslib "^1.7.1"
+
 "@testeditor/workspace-navigator@~0.26.0":
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/@testeditor/workspace-navigator/-/workspace-navigator-0.26.0.tgz#5f97506f3461ea4fa76355b379fe19a34ad059e1"


### PR DESCRIPTION
very(!) rudimentary proof that the testexec-navigator packaging and deployment works in principle, and that it can be used from within test-editor-web.
This currently just includes the testexec-navigator's NavigatorComponent (which just writes _navigator works!_ to the page…) to the right-hand side of the editor area.

… we probably want to hold off on merging this until testexec-navigator at least shows a basic test tree view.

And another thing: the tests (specifically `ace.component.spec.ts`) don't seem to be fully isolated, i.e. they influence each other. I guess we updated some test dependencies (Jasmine, Karma), and I think the tests are now run in randomized order, which means that they _sometimes_ fail on account of a previous test not properly cleaning up after itself… :confounded: 