### PR TITLE
fixes height as long as tabs fit into a single row

### DIFF
--- a/src/app/editor-tabs/editor-tabs.component.css
+++ b/src/app/editor-tabs/editor-tabs.component.css
@@ -14,3 +14,13 @@ tab {
 ::ng-deep .tab-content {
   height: calc(100% - 35px);
 }
+
+#editor-tabs {
+  /** For some reason, the tabs cause some "excess height",
+    * prompting browsers to show a scroll bar for this container.
+    * At the time of testing this, Firefox is off by 14 pixels,
+    * whereas Chrome stops showing the scrollbar when at least
+    * 7 pixels are subtracted.
+    */
+  height: calc(100% - 14px);
+}

--- a/src/app/editor-tabs/editor-tabs.component.html
+++ b/src/app/editor-tabs/editor-tabs.component.html
@@ -1,6 +1,6 @@
-<div (click)="$event.preventDefault()">
+<div id="editor-tabs" (click)="$event.preventDefault()">
   <tabset>
-    <tab *ngFor="let tab of tabs" 
+    <tab *ngFor="let tab of tabs"
       [heading]="tab.title"
       [id]="tab.id"
       [active]="tab.active"


### PR DESCRIPTION
the extra height seems to accumulate from a couple of different css settings like border-widths, but also some weird negative length settings. This seems to amount to 7 [14] pixels that somehow don't get accounted for when Chrome [Firefox] calculates the overall content height of the editor and its tabs. 

When the tabs start taking up more than one row, the scrollbar will still appear, but I figure in that case, that's the (more or less) desired behavior.