### PR TITLE
set bg color of container to match teststep selector

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -37,3 +37,7 @@
 .navigation-text:hover {
   cursor: pointer;
 }
+
+#test-step-selector-area {
+  background-color: #252525;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -14,7 +14,7 @@
         <split-area size="60">
           <app-editor-tabs></app-editor-tabs>
         </split-area>
-        <split-area size="20" *ngIf="isAuthorized && hasToken">
+        <split-area id="test-step-selector-area" size="20" *ngIf="isAuthorized && hasToken">
           <app-test-step-selector></app-test-step-selector>
         </split-area>
       </split>


### PR DESCRIPTION
without this, when collapsing the nodes of the teststep selector, at some point the bottom part will reveal itself to be white, which looks awkward…