### PR TITLE
fix tests not executing an `expect(…)` statement

### DIFF
--- a/src/app/editor-tabs/ace.component.spec.ts
+++ b/src/app/editor-tabs/ace.component.spec.ts
@@ -123,6 +123,7 @@ describe('AceComponent', () => {
 
       // then
       verify(editorSpy.setValue(editorContentAfterMerge)).once();
+      expect().nothing();
   });
   }));
 

--- a/src/app/service/execution/test-execution-suite-adapter.service.spec.ts
+++ b/src/app/service/execution/test-execution-suite-adapter.service.spec.ts
@@ -36,6 +36,7 @@ describe('TestExecutionSuiteAdapterService', () => {
 
     // then
     verify(mockDelegateService.execute(path)).once();
+    expect().nothing();
   }));
 
   it('returns the status of a previously started test suite', inject([TestExecutionSuiteAdapterService],

--- a/src/app/service/execution/test-suite-execution.service.spec.ts
+++ b/src/app/service/execution/test-suite-execution.service.spec.ts
@@ -79,6 +79,7 @@ describe('TestSuiteExecutionService', () => {
 
     // then
     httpMock.expectOne(testExecutionRequest);
+    expect().nothing();
   })));
 
   it('getStatus returns TestSuiteExecutionStatus object containing the test state returned by the server',
@@ -117,6 +118,7 @@ describe('TestSuiteExecutionService', () => {
 
     // then
     httpMock.expectOne(testExecutionRequest);
+    expect().nothing();
   })));
 
   it('getAllStatus returns an array of TestSuiteExecutionStatus object',

--- a/src/app/service/syntaxHighlighting/syntax.highlighting.service.spec.ts
+++ b/src/app/service/syntaxHighlighting/syntax.highlighting.service.spec.ts
@@ -1,4 +1,5 @@
 import { AceClientsideSyntaxHighlightingService } from './ace.clientside.syntax.highlighting.service';
+import { async } from '@angular/core/testing';
 
 describe('AceClientsideSyntaxHighlightingService', () => {
 
@@ -8,7 +9,7 @@ describe('AceClientsideSyntaxHighlightingService', () => {
     serviceUnderTest = new AceClientsideSyntaxHighlightingService();
   });
 
-  it('throws exception for unknown language', () => {
+  it('throws exception for unknown language', async(() => {
     // given
     const unknownLanguageExtension = 'unknown';
 
@@ -20,7 +21,7 @@ describe('AceClientsideSyntaxHighlightingService', () => {
       .catch(actualReason => {
         expect(actualReason).toEqual(`No syntax highlighting available for language extension "${unknownLanguageExtension}"`);
       });
-  });
+  }));
 
 
   // given
@@ -32,7 +33,7 @@ describe('AceClientsideSyntaxHighlightingService', () => {
     ['aml', 'xtext-resources/generated/mode-aml']
   ].forEach(([knownLanguageExtension, expectedSyntaxHighlightingFile]) => {
 
-    it(`provides Ace syntax highlighting file "${expectedSyntaxHighlightingFile}" for language "${knownLanguageExtension}"`, () => {
+    it(`provides Ace syntax highlighting file "${expectedSyntaxHighlightingFile}" for language "${knownLanguageExtension}"`, async(() => {
       // when
       const syntaxHighlightingResult = serviceUnderTest.getSyntaxHighlighting(knownLanguageExtension);
 
@@ -40,7 +41,7 @@ describe('AceClientsideSyntaxHighlightingService', () => {
       syntaxHighlightingResult.then(actualHighlighting => {
         expect(actualHighlighting).toEqual(expectedSyntaxHighlightingFile);
       }).catch(exceptionReason => fail(`unexpected exception: ${exceptionReason}`));
-    });
+    }));
 
   });
 });


### PR DESCRIPTION
Jasmine issues a warning ("SPEC HAS NO EXPECTATIONS") in this case. Some of our tests use ts-mockito's `verify`, or Angular's `HttpTestingController` (e.g.e `expectOne`). In this case, adding Jasmine's `expect().nothing()` suppresses the warning (see [here](https://github.com/jasmine/jasmine/issues/1221)). There were also some tests that, due to asynchronous execution, never actually checked their expectations, which I fixed by surrounding the test body with Angular's `async`.