### PR TITLE
set testexec-details to update patch version automatically.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@angular/router": "^5.2.10",
     "@testeditor/messaging-service": "~1.4.0",
     "@testeditor/testeditor-commons": "~0.1.0",
-    "@testeditor/testexec-details": "~0.3.13",
+    "@testeditor/testexec-details": "~0.3.0",
     "@testeditor/testexec-navigator": "~0.4.0",
     "@testeditor/teststep-selector": "~0.1.0",
     "@testeditor/workspace-navigator": "~0.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,9 +204,9 @@
   dependencies:
     tslib "^1.7.1"
 
-"@testeditor/testexec-details@~0.3.13":
-  version "0.3.13"
-  resolved "https://registry.yarnpkg.com/@testeditor/testexec-details/-/testexec-details-0.3.13.tgz#98ac780f6a66242749f50d502e0bbe6c80123618"
+"@testeditor/testexec-details@~0.3.0":
+  version "0.3.14"
+  resolved "https://registry.yarnpkg.com/@testeditor/testexec-details/-/testexec-details-0.3.14.tgz#560cfaad687acfb91c16debdbf14052c5d3407d3"
   dependencies:
     tslib "^1.7.1"
 


### PR DESCRIPTION
Note: This hadn't worked for some reason, earlier.
Now, after resetting the patch-level version in the package.json file to '0' again,
a `yarn build` correctly upgraded to version 0.3.14, as reflected
in the yarn.lock file.