### PR TITLE
fix Dockerfile + run script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,15 +26,17 @@ ENV WORK_DIR=/usr/share/nginx/html
 
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY nginx.default.conf /etc/nginx/conf.d/default.conf
+COPY dist ${WORK_DIR}/
+COPY run.sh ${WORK_DIR}/
 
 RUN chmod -R 777 /var/log/nginx /var/cache /var/run && \
     chmod -R 777 /etc/nginx/* && \
     chmod -R 777 /usr/share/nginx/*
 
-COPY dist ${WORK_DIR}/
+EXPOSE 4200
 
 USER nginx
 
-EXPOSE 4200
+WORKDIR ${WORK_DIR}
 
-ENTRYPOINT [ "./run.sh" ]
+ENTRYPOINT [ "/bin/sh", "run.sh" ]

--- a/run.sh
+++ b/run.sh
@@ -6,4 +6,4 @@ else
   echo "WARNING: environment variable 'APP_CONFIG' not set. Defaults will be used."
 fi
 
-nginx -g daemon off;
+nginx -g "daemon off;"


### PR DESCRIPTION
* run script wasn't even copied into the container
* working directory was not properly set
* couldn't get "./run.sh" to work as entrypoint (regardless of file attributes…), so now its invoked in a subshell.
* nginx invocation lacked quotes around global directive `daemon off;`