### PR TITLE
use version 0.5.0 of testeditor-commons

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/router": "^5.2.10",
     "@testeditor/messaging-service": "~1.4.0",
     "@testeditor/test-navigator": "~0.1.0",
-    "@testeditor/testeditor-commons": "~0.4.0",
+    "@testeditor/testeditor-commons": "~0.5.0",
     "@testeditor/testexec-details": "~0.3.0",
     "@testeditor/testexec-navigator": "~0.4.0",
     "@testeditor/teststep-selector": "~0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -220,16 +220,16 @@
   integrity sha512-M9rF57W3EcLyvZvmA/GKho9D/SKKeloIvoOx+DvMRfuNB6hnrWdPR4tdrCXVAbZAQe2Y237uxdhnK7HbsUXgkw==
 
 "@testeditor/test-navigator@~0.1.0":
-  version "0.1.31"
-  resolved "https://registry.yarnpkg.com/@testeditor/test-navigator/-/test-navigator-0.1.31.tgz#e7c40bc968e9fa79ffe3b6eb6e21f31d1b314abb"
-  integrity sha512-oSn/AVCQSYy+iTMoQCZyf9w65bGgfJHey/w+Fw8P+pkOHXQba3HPpI8KwJe5oYy0tpSEJ+DROCWWIbSqiCy3sg==
+  version "0.1.33"
+  resolved "https://registry.yarnpkg.com/@testeditor/test-navigator/-/test-navigator-0.1.33.tgz#6665e2d169ab175d34cd287f8a448c55360d9a9f"
+  integrity sha512-1L/h9Ue7bjCDweepU5ChstTrwObkJLFgqa7NI+0AQ6N399NPnCOgp40rApntfdgQ/CQb2FuwMveVAPqS4pITTQ==
   dependencies:
     tslib "^1.7.1"
 
-"@testeditor/testeditor-commons@~0.3.0":
-  version "0.3.12"
-  resolved "https://registry.yarnpkg.com/@testeditor/testeditor-commons/-/testeditor-commons-0.3.12.tgz#9914ca485f4078d411f46433aea3dc86d3b61544"
-  integrity sha512-i/B7/2NZ14npNv2qxiNQs97E3Z3YdaZA0a0A/pnkupBVstNhgAl56jkXze3yjRFys+aN9pgnLtS1fV8Hfda9lw==
+"@testeditor/testeditor-commons@~0.5.0":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@testeditor/testeditor-commons/-/testeditor-commons-0.5.2.tgz#87cc28a7f5c9463a3280adc9bf569af5c7bd692b"
+  integrity sha512-7NNo9G5ceK2X1txAh54S+blkjkb5xA3kkyicm7vOg2Yp3Fwh9DQ0NuSTR3Ibq7PzNSVRqtEXtkbtCRmDc9Q/3g==
   dependencies:
     tslib "^1.7.1"
 
@@ -255,9 +255,9 @@
     tslib "^1.7.1"
 
 "@testeditor/user-activity@~0.0.0":
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/@testeditor/user-activity/-/user-activity-0.0.6.tgz#4d5b1cc4e70b00fd7a83a738795f7f411727d0b9"
-  integrity sha512-KBdbQmTt810Z9IKJKml7UcJ9SutsR/RYUgpKUwz4jbuv21vxc1RGfz4092KLrUsXpdEtzXhZ26T6+bFEQvPN6A==
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@testeditor/user-activity/-/user-activity-0.0.7.tgz#b6b629c6a2cbb549a9111438fcf12b84eb35bf1f"
+  integrity sha512-0XTeU5e8bdJK0UiMInYs1oC4zX0/DtT3F985q48UUkPbPALTfQi11RDdydcHCNXKdhUBGI87J0lsu/+BjOmc8w==
   dependencies:
     tslib "^1.7.1"
 


### PR DESCRIPTION
Wait for all other relevant frontend projects to have "stabilized" (published releases with latest changes)