### PR TITLE
rename tabs if ancestor folder was renamed

### DIFF
--- a/src/app/editor-tabs/editor-tabs.component.spec.ts
+++ b/src/app/editor-tabs/editor-tabs.component.spec.ts
@@ -12,7 +12,7 @@ import { DocumentService } from '../service/document/document.service';
 
 import { NAVIGATION_DELETED, NAVIGATION_OPEN,
          EDITOR_ACTIVE, EDITOR_CLOSE, EDITOR_OPEN,
-         NavigationDeletedPayload, NavigationOpenPayload } from './event-types';
+         NavigationDeletedPayload, NavigationOpenPayload, NavigationRenamedPayload, NAVIGATION_RENAMED } from './event-types';
 import { AceClientsideSyntaxHighlightingService } from '../service/syntaxHighlighting/ace.clientside.syntax.highlighting.service';
 import { SyntaxHighlightingService } from '../service/syntaxHighlighting/syntax.highlighting.service';
 import { TestEditorConfiguration } from 'app/config/test-editor-configuration';
@@ -279,4 +279,19 @@ describe('EditorTabsComponent', () => {
     expect(getActiveItem().nativeElement.innerText).toBe('bar');
   });
 
+  it('renames tab when corresponding event of a parent is received', () => {
+    // given
+    openFooAndBar();
+    const unaffectedTab = component.tabs[0];
+    const affectedTab = component.tabs[1];
+    const renamePayload: NavigationRenamedPayload = { oldPath: 'tropical', newPath: 'caribbean' };
+
+    // when
+    messagingService.publish(NAVIGATION_RENAMED, renamePayload);
+    fixture.detectChanges();
+
+    // then
+    expect(unaffectedTab.path).toEqual('top/secret/foo');
+    expect(affectedTab.path).toEqual('caribbean/bar');
+  });
 });

--- a/src/app/editor-tabs/editor-tabs.component.ts
+++ b/src/app/editor-tabs/editor-tabs.component.ts
@@ -115,10 +115,9 @@ export class EditorTabsComponent implements OnInit, OnDestroy, TabInformer {
   }
 
   private handleNavigationRenamed(payload: NavigationRenamedPayload): void {
-    const existingTab = this.findTab(payload.oldPath);
-    if (existingTab) {
-      this.renameTab(existingTab, payload.oldPath, payload.newPath);
-    }
+    this.findDescendantTabs(payload.oldPath).forEach((tab) => {
+      this.renameTab(tab, tab.path, payload.newPath + tab.path.substring(payload.oldPath.length));
+    });
   }
 
   private renameTab(tab: any, oldPath: string, newPath: string) {
@@ -144,6 +143,10 @@ export class EditorTabsComponent implements OnInit, OnDestroy, TabInformer {
 
   private findTab(path: string): TabElement {
     return this.tabs.find(tab => tab.path === path);
+  }
+
+  private findDescendantTabs(parentPath: string): TabElement[] {
+    return this.tabs.filter(tab => tab.path.startsWith(parentPath));
   }
 
   private findTabsBelowFolder(folder: string): TabElement[] {


### PR DESCRIPTION
Open tabs need to react to rename events of both the directly corresponding file, as well as any ancestor directories, as their renaming will affect their path.