### PR TITLE
upgrade to JQuery 3.4.1 to address CVE-2019-11358

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "bootstrap": "^4.3.1",
     "core-js": "^2.5.5",
     "font-awesome": "^4.7.0",
-    "jquery": "^3.3.1",
+    "jquery": "^3.4.0",
     "ng4-loading-spinner": "~1.2.0",
     "ngx-bootstrap": "^2.0.4",
     "popper.js": "^1.14.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,9 +3553,10 @@ jasminewd2@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jasminewd2/-/jasminewd2-2.2.0.tgz#e37cf0b17f199cce23bea71b2039395246b4ec4e"
 
-jquery@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+jquery@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
https://github.com/test-editor/test-editor-web/network/alert/yarn.lock/jquery/open