### PR TITLE
do not execute e2e tests on Chrome due to protractor incompatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ script:
 - nix-shell shell-${FIREFOX_VERSION}.nix --command "firefox --version"
 - nix-shell shell-${FIREFOX_VERSION}.nix --command "google-chrome --version"
 - nix-shell shell-${FIREFOX_VERSION}.nix --command "xvfb-run --server-args=\"-ac -screen 0 1920x1080x16\" yarn run testCIFirefox"
-- nix-shell shell-${FIREFOX_VERSION}.nix --command "xvfb-run --server-args=\"-ac -screen 0 1920x1080x16\" yarn run e2e" # currently non functional
 - nix-shell shell-${FIREFOX_VERSION}.nix --command "yarn run build" # includes lint
 - if [[ ( "$TRAVIS_PULL_REQUEST" = "false" ) && ( "$FIREFOX_VERSION" = "latest" ) && (( "$TRAVIS_BRANCH" = "master" ) || ( "$TRAVIS_TAG" != "" )) ]]; then nix-shell shell-${FIREFOX_VERSION}.nix --command  "yarn run docker:build" && export TE_DEPLOY=true; fi
 


### PR DESCRIPTION
Protractor uses its own version of webdriver manager, which is too old to support Chrome 76.

* https://github.com/angular/webdriver-manager/issues/404
* https://github.com/angular/protractor/issues/5289

Its really not worth the effort implementing any of the suggested workarounds.
For now, the e2e tests on Chrome will simply not be executed on Travis.
Once Protractor 5 is updated with the latest webdriver manager version, we can turn them back on again.